### PR TITLE
Add Windows functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+go:
+  - 1.5
+  - 1.6
+
+branches:
+  only:
+    - master
+
+# Don't test vendor directory (go test ./... will test these by default and fsnotify causes problems)
+script:
+  - go test . ./server ./client ./server/auth ./server/keydb ./log
+
+notifications:
+  email:
+    recipients:
+    - devinlundberg@pinterest.com
+    on_success: never
+    on_failure: change
+env:
+  global:
+    - GO15VENDOREXPERIMENT=1

--- a/client/flock_unix.go
+++ b/client/flock_unix.go
@@ -1,0 +1,75 @@
+// Based on https://github.com/boltdb/bolt/blob/master/bolt_unix.go
+// Copyright boltdb authors
+
+// +build !windows,!plan9,!solaris
+
+package client
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"time"
+)
+
+// ErrTimeout is returned when we cannot obtain an exclusive lock
+// on the key file.
+var ErrTimeout = errors.New("timeout")
+
+type flock struct {
+	fd int
+}
+
+func newFlock() *flock {
+	return &flock{-1}
+}
+
+// lock acquires an advisory lock on a file descriptor.
+func (f *flock) lock(k *KeysFile, mode os.FileMode, exclusive bool, timeout time.Duration) error {
+	var t time.Time
+	for {
+		// If we're beyond our timeout then return an error.
+		// This can only occur after we've attempted a lock once.
+		if t.IsZero() {
+			t = time.Now()
+		} else if timeout > 0 && time.Since(t) > timeout {
+			return ErrTimeout
+		}
+		flag := syscall.LOCK_SH
+		if exclusive {
+			flag = syscall.LOCK_EX
+		}
+
+		// Otherwise attempt to obtain an exclusive lock.
+		fd, err := f.getFD(k)
+		if err != nil {
+			return err
+		}
+		err = syscall.Flock(fd, flag|syscall.LOCK_NB)
+		if err == nil {
+			return nil
+		} else if err != syscall.EWOULDBLOCK {
+			return err
+		}
+
+		// Wait for a bit and try again.
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// unlock releases an advisory lock on a file descriptor.
+func (f *flock) unlock(k *KeysFile) error {
+	return syscall.Flock(f.fd, syscall.LOCK_UN)
+}
+
+func (f *flock) getFD(k *KeysFile) (int, error) {
+	if f.fd != -1 {
+		return f.fd, nil
+	}
+	fd, err := syscall.Open(k.fn, syscall.O_RDWR, 0)
+	if err != nil {
+		return -1, err
+	}
+	f.fd = fd
+	return f.fd, nil
+}

--- a/client/flock_windows.go
+++ b/client/flock_windows.go
@@ -1,0 +1,101 @@
+// Based on https://github.com/boltdb/bolt/blob/master/bolt_windows.go
+// Copyright boltdb authors
+
+package client
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// LockFileEx code derived from golang build filemutex_windows.go @ v1.5.1
+var (
+	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = modkernel32.NewProc("LockFileEx")
+	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
+
+	// ErrTimeout is returned when we cannot obtain an exclusive lock
+	// on the key file.
+	ErrTimeout = errors.New("timeout")
+)
+
+const (
+	lockExt = ".lock"
+
+	// see https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
+	flagLockExclusive       = 2
+	flagLockFailImmediately = 1
+
+	// see https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
+	errLockViolation syscall.Errno = 0x21
+)
+
+func lockFileEx(h syscall.Handle, flags, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	r, _, err := procLockFileEx.Call(uintptr(h), uintptr(flags), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)))
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
+func unlockFileEx(h syscall.Handle, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	r, _, err := procUnlockFileEx.Call(uintptr(h), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)), 0)
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
+type flock struct {
+	lockfile *os.File
+}
+
+func newFlock() *flock {
+	return &flock{&os.File{}}
+}
+
+// lock acquires an advisory lock on a file descriptor.
+func (f *flock) lock(k *KeysFile, mode os.FileMode, exclusive bool, timeout time.Duration) error {
+	// Create a separate lock file on windows because a process
+	// cannot share an exclusive lock on the same file.
+	file, err := os.OpenFile(k.fn+lockExt, os.O_CREATE, mode)
+	if err != nil {
+		return err
+	}
+	f.lockfile = file
+	var t time.Time
+	for {
+		// If we're beyond our timeout then return an error.
+		// This can only occur after we've attempted a lock once.
+		if t.IsZero() {
+			t = time.Now()
+		} else if timeout > 0 && time.Since(t) > timeout {
+			return ErrTimeout
+		}
+
+		var flag uint32 = flagLockFailImmediately
+		if exclusive {
+			flag |= flagLockExclusive
+		}
+		err = lockFileEx(syscall.Handle(f.lockfile.Fd()), flag, 0, 1, 0, &syscall.Overlapped{})
+		if err == nil {
+			return nil
+		} else if err != errLockViolation {
+			return err
+		}
+
+		// Wait for a bit and try again.
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// unlock releases an advisory lock on a file descriptor.
+func (f *flock) unlock(k *KeysFile) error {
+	err := unlockFileEx(syscall.Handle(f.lockfile.Fd()), 0, 1, 0, &syscall.Overlapped{})
+	f.lockfile.Close()
+	os.Remove(k.fn + lockExt)
+	return err
+}

--- a/client/unregister.go
+++ b/client/unregister.go
@@ -22,10 +22,15 @@ func runUnregister(cmd *Command, args []string) {
 		fatalf("You must include a key ID to deregister. See 'knox help unregister'")
 	}
 	k := NewKeysFile(daemonFolder + daemonToRegister)
-	err := k.Remove([]string{args[0]})
-
+	err := k.Lock()
 	if err != nil {
-		fatalf(err.Error())
+		fatalf("Error locking the register file: %s", err.Error())
+	}
+	defer k.Unlock()
+
+	err = k.Remove([]string{args[0]})
+	if err != nil {
+		fatalf("Error removing the key: %s", err.Error())
 	}
 	fmt.Println("Unregistered key successfully")
 }

--- a/cmd/migrate_db/main.go
+++ b/cmd/migrate_db/main.go
@@ -62,8 +62,8 @@ func generateTestDBWithKeys(crypt keydb.Cryptor) keydb.DB {
 }
 
 func main() {
-	crypt1 := keydb.NewLegacyAESCryptor(0, make([]byte, 16))
-	crypt2 := keydb.NewLegacyAESCryptor(1, make([]byte, 16))
+	crypt1 := keydb.NewAESGCMCryptor(0, make([]byte, 16))
+	crypt2 := keydb.NewAESGCMCryptor(1, make([]byte, 16))
 
 	source := generateTestDBWithKeys(crypt1)
 


### PR DESCRIPTION
This PR fixes https://github.com/pinterest/knox/issues/3 ("Knox client doesn't support Windows").

The file locking / unlocking functionality is based on https://github.com/golang/build/blob/master/cmd/builder/filemutex_windows.go

`go test` passes, and the client seems to work (Windows 10 Pro x64, Go 1.6.1), but these changes probably shouldn't be merged without proper code review.