### PR TITLE
fixed None.CanAccess(Admin)

### DIFF
--- a/knox.go
+++ b/knox.go
@@ -134,14 +134,14 @@ func (s PrincipalType) MarshalJSON() ([]byte, error) {
 type AccessType int
 
 const (
+	// None denotes no access.
+	None AccessType = iota
 	// Read denotes the ability to read key data.
-	Read AccessType = iota
+	Read
 	// Write denotes the ability to add key versions and perform rotation.
 	Write
 	// Admin denotes the ability to delete the key and modify the ACL.
 	Admin
-	// None denotes no access.
-	None
 )
 
 // UnmarshalJSON parses JSON input to set an AccessType.

--- a/knox_test.go
+++ b/knox_test.go
@@ -240,14 +240,17 @@ func TestACLAdd(t *testing.T) {
 
 }
 func TestAccessTypeCanAccess(t *testing.T) {
-	if Read.CanAccess(Admin) || Read.CanAccess(Write) || !Read.CanAccess(Read) {
+	if Read.CanAccess(Admin) || Read.CanAccess(Write) || !Read.CanAccess(Read) || !Read.CanAccess(None) {
 		t.Error("Read has incorrect access")
 	}
-	if Write.CanAccess(Admin) || !Write.CanAccess(Write) || !Write.CanAccess(Read) {
+	if Write.CanAccess(Admin) || !Write.CanAccess(Write) || !Write.CanAccess(Read) || !Write.CanAccess(None) {
 		t.Error("Write has incorrect access")
 	}
-	if !Admin.CanAccess(Admin) || !Admin.CanAccess(Write) || !Admin.CanAccess(Read) {
+	if !Admin.CanAccess(Admin) || !Admin.CanAccess(Write) || !Admin.CanAccess(Read) || !Admin.CanAccess(None) {
 		t.Error("Admin has incorrect access")
+	}
+	if None.CanAccess(Admin) || None.CanAccess(Write) || None.CanAccess(Read) || !None.CanAccess(None) {
+		t.Error("None has incorrect access")
 	}
 }
 


### PR DESCRIPTION
    By ordering the constants with None above Admin, the CanAccess method would evaluate to true for None. This would, in theory allow any Principal with a None AccessType on a resource to access them. Now, this is not a scenario that would normally happen as the AccessList ensures that there are no None values. However, if this behavior is changed in the future or you would want to have an ACL specifiying that anyone can access the resource (instead of not having an ACL), this would be something you would run into.

    Saw it when looking at your code, thought I would make a quick PR.