### PR TITLE
Combine knox get and register for scripted clients

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,15 +97,7 @@ func NewMock(primary string, active []string) Client {
 
 // Register registers the given keyName with knox. If the operation fails, it returns an error.
 func Register(keyID string) ([]byte, error) {
-	if output, err := exec.Command("knox", "register", "-k", keyID).CombinedOutput(); err != nil {
-		return nil, fmt.Errorf("error registering knox key: %s %v '%q'", keyID, err, output)
-	}
-	cmd := exec.Command("knox", "get", "-j", keyID)
-	host, err := os.Hostname()
-	if err != nil {
-		return nil, fmt.Errorf("No hostname found: %s", err.Error())
-	}
-	cmd.Env = []string{"KNOX_MACHINE_AUTH=" + host}
+	cmd := exec.Command("knox", "register", "-g", "-k", keyID)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("error getting knox key: %s %v '%q'", keyID, err, output)

--- a/client/daemon.go
+++ b/client/daemon.go
@@ -177,8 +177,9 @@ func (d *daemon) update() error {
 			if err != nil {
 				// Keep going in spite of failure
 				logf("error getting cache key: %s", err)
+			} else {
+				keyMap[keyID] = key.VersionHash
 			}
-			keyMap[keyID] = key.VersionHash
 		} else {
 			d.deleteKey(keyID)
 		}
@@ -246,7 +247,6 @@ func (d daemon) processKey(keyID string) error {
 		return fmt.Errorf("Error writing key %s to file: %s", keyID, err.Error())
 	}
 
-	// Need to chmod due to a umask set on masterless puppet machines
 	err = os.Chmod(d.keyFilename(keyID), defaultFilePermission)
 	if err != nil {
 		return fmt.Errorf("Failed to open up key file permissions: %s", err.Error())


### PR DESCRIPTION
This PR will allow for enforcing ACLs on client with changes to Knox client libs.

It is more efficient from a scripted client implementation (running one command instead of two as per the Register function in client.go), but we miss out on error messages. To fix error messages support we could cache errors on the file system, but this may have other implications, so I'll consider this as a separate issue