### PR TITLE
fix a bug of missing new line at the end of non-json log line

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -255,7 +255,7 @@ func (l *Logger) Output(calldepth int, s string) error {
 		return err
 	}
 
-	_, err = l.out.Write(t)
+	_, err = l.out.Write(append(t, '\n'))
 	return err
 }
 


### PR DESCRIPTION
newline character is missing in Output() function causing all the log lines to be written in the same line.  

This fix appends a newline to the message similar to OutputJSON() and OutputBinary(). 