### PR TITLE
Future proofing on Knox ACLs

### DIFF
--- a/client/getacl.go
+++ b/client/getacl.go
@@ -37,7 +37,7 @@ func runGetACL(cmd *Command, args []string) {
 	for _, a := range *acl {
 		aEnc, err := json.Marshal(a)
 		if err != nil {
-			fmt.Println("Could not unmarshal entry:", a)
+			fmt.Println("Could not marshal entry:", a)
 		}
 		fmt.Println(string(aEnc))
 	}

--- a/client/getacl.go
+++ b/client/getacl.go
@@ -37,7 +37,7 @@ func runGetACL(cmd *Command, args []string) {
 	for _, a := range *acl {
 		aEnc, err := json.Marshal(a)
 		if err != nil {
-			fmt.Println("Could not marshal entry:", a)
+			fatalf("Could not marshal entry:", a)
 		}
 		fmt.Println(string(aEnc))
 	}

--- a/client/getacl.go
+++ b/client/getacl.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 )
 
 func init() {
@@ -35,7 +35,10 @@ func runGetACL(cmd *Command, args []string) {
 	}
 
 	for _, a := range *acl {
-		aEnc, _ := json.Marshal(a)
-		fmt.Println(string(aEnc))		
+		aEnc, err := json.Marshal(a)
+		if err != nil {
+			fmt.Println("Could not unmarshal entry:", a)
+		}
+		fmt.Println(string(aEnc))
 	}
 }

--- a/knox.go
+++ b/knox.go
@@ -86,6 +86,9 @@ func (s VersionStatus) MarshalJSON() ([]byte, error) {
 // is represented. This allows for users and machines to be bucketed together.
 type PrincipalType int
 
+// Unknown represents a bad PrincipalType that cannot be marshaled
+const Unknown PrincipalType = -1
+
 const (
 	// User represents a single LDAP User.
 	User PrincipalType = iota
@@ -116,7 +119,7 @@ func (s *PrincipalType) UnmarshalJSON(b []byte) error {
 		// To ensure compatibilty in the event of new PrincipalTypes, don't
 		// throw an error. Instead just create a bogus Type. When displaying
 		// the ACL to the user, fail on the single entry. GetKey & GetACL will work.
-		*s = -1
+		*s = Unknown
 	}
 	return nil
 }
@@ -134,6 +137,9 @@ func (s PrincipalType) MarshalJSON() ([]byte, error) {
 		return json.Marshal("MachinePrefix")
 	case Service:
 		return json.Marshal("Service")
+	case Unknown:
+		// Explicitly prevent unrecognized PrincipalTypes from being marshaled
+		return nil, invalidTypeError{"PrincipalType"}
 	default:
 		return nil, invalidTypeError{"PrincipalType"}
 	}

--- a/knox.go
+++ b/knox.go
@@ -86,12 +86,11 @@ func (s VersionStatus) MarshalJSON() ([]byte, error) {
 // is represented. This allows for users and machines to be bucketed together.
 type PrincipalType int
 
-// Unknown represents a bad PrincipalType that cannot be marshaled
-const Unknown PrincipalType = -1
-
 const (
+	// Unknown represents a bad PrincipalType that cannot be marshaled
+	Unknown PrincipalType = -1
 	// User represents a single LDAP User.
-	User PrincipalType = iota
+	User = iota
 	// UserGroup represents an LDAP security group.
 	UserGroup
 	// Machine represents the host of a machine.

--- a/knox.go
+++ b/knox.go
@@ -113,7 +113,10 @@ func (s *PrincipalType) UnmarshalJSON(b []byte) error {
 	case `"Service"`:
 		*s = Service
 	default:
-		return invalidTypeError{"PrincipalType"}
+		// To ensure compatibilty in the event of new PrincipalTypes, don't
+		// throw an error. Instead just create a bogus Type. When displaying
+		// the ACL to the user, fail on the single entry. GetKey & GetACL will work.
+		*s = -1
 	}
 	return nil
 }

--- a/knox_test.go
+++ b/knox_test.go
@@ -149,9 +149,13 @@ func TestPrincipalTypeMarshaling(t *testing.T) {
 		t.Error("Marshaled invalid enum")
 	}
 	unmarshalErr := invalid.UnmarshalJSON([]byte("ThisInputIsNotValid"))
-	if unmarshalErr == nil {
-		t.Error("Unmarshaled invalid string")
+	if unmarshalErr != nil {
+		t.Error("Did not unmarshal invalid string")
 	}
+	if invalid != -1 {
+		t.Error("Unmarshalling invalid Principal type should result in -1")
+	}
+
 }
 func TestVersionStatusMarshaling(t *testing.T) {
 	for _, in := range []VersionStatus{Primary, Active, Inactive} {


### PR DESCRIPTION
Old client versions cannot read keys that have Service PrincipalTypes in their ACLs. This is due to a failure to unmarshal the JSON blob returned from the server into a Access object. By returning (-1), we succeed in unmarshalling the JSON blob, but will fail to display the individual ACL entry in a meaningful way. We handle this by catching the Marshal error when displaying the ACL.

This will ease the pain if another PrincipalType is added down the line.

For example, 

```
❯ ./knox acl jkrach:test
{"type":"User","id":"jkrach","access":"Admin"}
Could not unmarshal entry: {-1 spiffe://example.com/serviceA 1}

❯ ./knox get jkrach:test                                
secret!%
```