### PR TITLE
Add retries for concurrent key-write commands that throw server errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -16,6 +17,11 @@ import (
 )
 
 const refresh = 10 * time.Second
+
+// For linear random backoff on write requests.
+const baseBackoff = 50 * time.Millisecond
+const maxBackoff = 3 * time.Second
+const maxRetryAttempts = 3
 
 // Client is an interface for interacting with a specific knox key
 type Client interface {
@@ -104,6 +110,18 @@ func Register(keyID string) ([]byte, error) {
 		return nil, fmt.Errorf("error getting knox key: %s %v '%q'", keyID, err, output)
 	}
 	return output, nil
+}
+
+// GetBackoffDuration returns a time duration to sleep based on the attempt #.
+func GetBackoffDuration(attempt int) time.Duration {
+	basef := float64(baseBackoff)
+	// Add some randomness.
+	duration := rand.Float64()*float64(attempt) + basef
+
+	if duration > float64(maxBackoff) {
+		return maxBackoff
+	}
+	return time.Duration(duration)
 }
 
 // APIClient is an interface that talks to the knox server for key management.
@@ -262,8 +280,6 @@ func (c *HTTPClient) getClient() (HTTP, error) {
 }
 
 func (c *HTTPClient) getHTTPData(method string, path string, body url.Values, data interface{}) error {
-	var err error
-
 	r, err := http.NewRequest(method, "https://"+c.Host+path, bytes.NewBufferString(body.Encode()))
 
 	if err != nil {
@@ -285,20 +301,30 @@ func (c *HTTPClient) getHTTPData(method string, path string, body url.Values, da
 	if err != nil {
 		return err
 	}
-	w, err := cli.Do(r)
-	if err != nil {
-		return err
+
+	// Contains retry logic if we decode a 500 error.
+	for i := 1; i <= maxRetryAttempts; i++ {
+		w, err := cli.Do(r)
+		if err != nil {
+			return err
+		}
+		resp := &Response{}
+		resp.Data = data
+		decoder := json.NewDecoder(w.Body)
+		err = decoder.Decode(resp)
+		if err != nil {
+			return err
+		}
+		if resp.Status != "ok" {
+			if (resp.Message != "Internal Server Error") || (i == maxRetryAttempts) {
+				return fmt.Errorf(resp.Message)
+			}
+			time.Sleep(GetBackoffDuration(i))
+		} else {
+			break
+		}
 	}
-	resp := &Response{}
-	resp.Data = data
-	decoder := json.NewDecoder(w.Body)
-	err = decoder.Decode(resp)
-	if err != nil {
-		return err
-	}
-	if resp.Status != "ok" {
-		return fmt.Errorf(resp.Message)
-	}
+
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -316,7 +316,7 @@ func (c *HTTPClient) getHTTPData(method string, path string, body url.Values, da
 			return err
 		}
 		if resp.Status != "ok" {
-			if (resp.Message != "Internal Server Error") || (i == maxRetryAttempts) {
+			if (resp.Code != InternalServerErrorCode) || (i == maxRetryAttempts) {
 				return fmt.Errorf(resp.Message)
 			}
 			time.Sleep(GetBackoffDuration(i))

--- a/client_test.go
+++ b/client_test.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 )
+
+var ops uint64
 
 func TestMockClient(t *testing.T) {
 	p := "primary"
@@ -26,16 +29,6 @@ func TestMockClient(t *testing.T) {
 	}
 }
 
-// buildServer returns a server. Call Close when finished.
-func buildServer(code int, body []byte, a func(r *http.Request)) *httptest.Server {
-	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		a(r)
-		w.WriteHeader(code)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(body)
-	}))
-}
-
 func buildGoodResponse(data interface{}) ([]byte, error) {
 	resp := &Response{
 		Status:    "ok",
@@ -47,6 +40,53 @@ func buildGoodResponse(data interface{}) ([]byte, error) {
 	}
 	return json.Marshal(resp)
 
+}
+
+func buildInternalServerErrorResponse(data interface{}) ([]byte, error) {
+	resp := &Response{
+		Status:		 "err",
+		Code:			 InternalServerErrorCode,
+		Host:			 "test",
+		Timestamp: 1234567890,
+		Message:	 "Internal Server Error",
+		Data:			 data,
+	}
+	return json.Marshal(resp)
+
+}
+
+// buildServer returns a server. Call Close when finished.
+func buildServer(code int, body []byte, a func(r *http.Request)) *httptest.Server {
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		a(r)
+		w.WriteHeader(code)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	}))
+}
+
+func buildConcurrentServer(code int, t *testing.T, a func(r *http.Request)) *httptest.Server {
+	var resp []byte
+	var err error
+
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		a(r)
+		w.WriteHeader(code)
+		w.Header().Set("Content-Type", "application/json")
+
+		if ops % 2 == 0 {
+			resp, err = buildGoodResponse("")
+			if err != nil {
+				t.Fatalf("%s is not nil", err)
+			}
+		} else {
+			resp, err = buildInternalServerErrorResponse("")
+			if err != nil {
+				t.Fatalf("%s is not nil", err)
+			}
+		}
+		w.Write(resp)
+	}))
 }
 
 func TestGetKey(t *testing.T) {
@@ -315,5 +355,36 @@ func TestPutAccess(t *testing.T) {
 	err = cli.PutAccess("testkey", a)
 	if err != nil {
 		t.Fatalf("%s is not nil", err)
+	}
+}
+
+func TestConcurrentDeletes(t *testing.T) {
+	srv := buildConcurrentServer(200, t, func(r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Fatalf("%s is not DELETE", r.Method)
+		}
+		if r.URL.Path != "/v0/keys/testkey1/" &&
+				r.URL.Path != "/v0/keys/testkey2/" {
+			t.Fatalf("%s is not the path for testkey1 or testkey2", r.URL.Path)
+		}
+		atomic.AddUint64(&ops, 1)
+	})
+	defer srv.Close()
+
+	cli := MockClient(srv.Listener.Addr().String())
+
+  // Delete 2 independent keys in succession.
+	err := cli.DeleteKey("testkey1")
+	if err != nil {
+		t.Fatalf("%s is not nil", err)
+	}
+	err = cli.DeleteKey("testkey2")
+	if err != nil {
+		t.Fatalf("%s is not nil", err)
+	}
+
+	// Verify that our atomic counter was incremented 4 times (2 attempts each)
+	if ops != 4 {
+		t.Fatalf("%d total client attempts is not 4", ops)
 	}
 }


### PR DESCRIPTION
Added up to three retries with random backoff per attempt to all write commands, upon receiving Internal Server Errors. These include:
- CreateKey
- DeleteKey
- PutAccess
- AddVersion
- UpdateVersion

Also added a test case testing the retry mechanism, by deleting two mocked keys concurrently, and seeing if an atomic counter was incremented twice per key.