### PR TITLE
Return local file paths with cached keys

### DIFF
--- a/client.go
+++ b/client.go
@@ -169,11 +169,12 @@ func (c *HTTPClient) CacheGetKey(keyID string) (*Key, error) {
 	if c.KeyFolder == "" {
 		return nil, fmt.Errorf("No folder set for cached key.")
 	}
-	b, err := ioutil.ReadFile(c.KeyFolder + keyID)
+	path := c.KeyFolder + keyID
+	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	k := Key{}
+	k := Key{Path: path}
 	err = json.Unmarshal(b, &k)
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -111,7 +111,9 @@ func TestGetKey(t *testing.T) {
 	if k.VersionHash != expected.VersionHash {
 		t.Fatalf("%s does not equal %s", k.VersionHash, expected.VersionHash)
 	}
-
+	if k.Path != "" {
+		t.Fatalf("path '%v' is not empty", k.Path)
+	}
 }
 
 func TestGetKeys(t *testing.T) {

--- a/knox.go
+++ b/knox.go
@@ -285,6 +285,7 @@ type Key struct {
 	ACL         ACL            `json:"acl"`
 	VersionList KeyVersionList `json:"versions"`
 	VersionHash string         `json:"hash"`
+	Path        string         `json:"path,omitempty"`
 }
 
 // Validate calls makes sure all attributes of key are in good state.

--- a/knox_test.go
+++ b/knox_test.go
@@ -1,6 +1,7 @@
 package knox_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -175,6 +176,29 @@ func TestVersionStatusMarshaling(t *testing.T) {
 	unmarshalErr := invalid.UnmarshalJSON([]byte("ThisInputIsNotValid"))
 	if unmarshalErr == nil {
 		t.Error("Unmarshaled invalid string")
+	}
+}
+func TestKeyPathMarhaling(t *testing.T) {
+	key := Key{
+		ID:          "test",
+		ACL:         ACL([]Access{}),
+		VersionList: KeyVersionList{},
+		VersionHash: "VersionHash",
+	}
+
+	out, err := json.Marshal(key)
+	if err != nil {
+		t.Errorf("Failed to marshal key: %v", err)
+	} else if bytes.Contains(out, []byte("path")) {
+		t.Errorf("Found unexpected 'path' key in JSON output")
+	}
+
+	key.Path = "/var/lib/knox/v0/keys/test:test"
+	out, err = json.Marshal(key)
+	if err != nil {
+		t.Errorf("Failed to marshal key: %v", err)
+	} else if !bytes.Contains(out, []byte("path")) {
+		t.Errorf("Expected 'path' key in JSON output")
 	}
 }
 


### PR DESCRIPTION
This change extends the knox.Key structure to include a Path field that
will contain the local path of the cached key file for registered keys.
The field will be empty and omitted when the key is fetched remotely.

This is useful for applications that register keys and then watch the
cached files for changes. Previously, these applications needed to know
both the root path (e.g., /var/lib/knox/v0/keys/) and naming format of
cached files. Now they can simply read the path directly from the
registration response.