### PR TITLE
Increase retry count 3 -> 5

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,8 +20,8 @@ const refresh = 10 * time.Second
 
 // For linear random backoff on write requests.
 const baseBackoff = 50 * time.Millisecond
-const maxBackoff = 3 * time.Second
-const maxRetryAttempts = 3
+const maxBackoff = 5 * time.Second
+const maxRetryAttempts = 5
 
 // Client is an interface for interacting with a specific knox key
 type Client interface {


### PR DESCRIPTION
Summary:
In extremely rare cases (one report since the last PR in mid-January, an internal server error is thrown to the knox_client. I suspect it's when 3 backoffs aren't enough, and collisions occur to zk in every attempt. We reduce this possibility even further by increasing the maximum number of retry attempts, since we are confident that retrying is an acceptable solution to address those 500s. 

Test Plan:
Ran unit tests