### PR TITLE
Added restrictions for adding acls with empty machineprefix

### DIFF
--- a/knox.go
+++ b/knox.go
@@ -14,6 +14,7 @@ import (
 var (
 	ErrACLDuplicateEntries = fmt.Errorf("Duplicate entries in ACL")
 	ErrACLContainsNone     = fmt.Errorf("ACL contains None access")
+	ErrACLEmptyMachinePrefix = fmt.Errorf("MachinePrefix cannot be empty while adding Read, Write, or Admin access.") 
 
 	ErrInvalidKeyID       = fmt.Errorf("KeyID can only contain alphanumeric characters, colons, and underscores.")
 	ErrInvalidVersionHash = fmt.Errorf("Hash does not match")

--- a/knox.go
+++ b/knox.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	ErrACLDuplicateEntries = fmt.Errorf("Duplicate entries in ACL")
-	ErrACLContainsNone     = fmt.Errorf("ACL contains None access")
-	ErrACLEmptyMachinePrefix = fmt.Errorf("MachinePrefix cannot be empty while adding Read, Write, or Admin access.") 
+	ErrACLDuplicateEntries   = fmt.Errorf("Duplicate entries in ACL")
+	ErrACLContainsNone       = fmt.Errorf("ACL contains None access")
+	ErrACLEmptyMachinePrefix = fmt.Errorf("MachinePrefix cannot be empty while adding Read, Write, or Admin access.")
 
 	ErrInvalidKeyID       = fmt.Errorf("KeyID can only contain alphanumeric characters, colons, and underscores.")
 	ErrInvalidVersionHash = fmt.Errorf("Hash does not match")

--- a/server/routes.go
+++ b/server/routes.go
@@ -300,6 +300,12 @@ func putAccessHandler(m KeyManager, principal knox.Principal, parameters map[str
 		return nil, errF(knox.UnauthorizedCode, "")
 	}
 
+	//Deny addition of ACLS with empty MachinePrefix for Read,Write,and Admin AccessType
+	//Empty MachinePrefix is allowed with None AccessType for revoking existing ACLS
+	if access.Type == knox.MachinePrefix  && access.ID == "" && access.AccessType != knox.None{
+                return nil, errF(knox.BadRequestDataCode,knox.ErrACLEmptyMachinePrefix.Error())
+	}
+
 	// Update Access
 	updateErr := m.UpdateAccess(keyID, access)
 	if updateErr != nil {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -359,6 +359,25 @@ func TestPutAccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}
+
+	//Tests for setting ACLs with empty machinePrefix  
+	//Should return error when used with AccessType Read,Write, or Admin
+	//Should return success when used with AccessType None(useful for revoking such existing ACLs)
+	accessTypes := []knox.AccessType{knox.None,knox.Read,knox.Write,knox.Admin}
+	for  _,accessType := range accessTypes{
+	    access = &knox.Access{Type: knox.MachinePrefix, ID: "", AccessType: accessType}
+	    accessJSON, jerr = json.Marshal(access)
+	    if jerr != nil {
+	    	t.Fatalf("%+v is not nil", jerr)
+	    }
+	    _, err = putAccessHandler(m, u, map[string]string{"keyID": "a1", "access": string(accessJSON)})
+	    if err == nil && accessType != knox.None{
+                  t.Fatal("Expected err") 
+	    } else if err != nil && accessType == knox.None{
+                  t.Fatalf("%+v is not nil",err)
+	    }
+        }
+
 }
 
 func TestPostVersion(t *testing.T) {


### PR DESCRIPTION
This PR removes the ability to create ACLs with empty MachinePrefix for Read, Write, or Admin Access.  ACLs with MachinePrefix  feature allows a particular Knox key to be Read/Written/Managed from any machine.

This feature was introduced to facilitate migration of existing keys to Knox with the intention that it would be replaced in future with ACLs containing actual hostnames/Spiffe Ids.

However, it came to our attention that this feature was misused and the key owners never went through the efforts of shortlisting the specific machines that need access to the key.

We are currently retaining only a small part the feature which allows setting empty MachinePrefix for None Access. This would be helpful to revoke existing keys.