### PR TITLE
Zero out ACL on getKey response. 

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -209,6 +209,8 @@ func getKeyHandler(m KeyManager, principal knox.Principal, parameters map[string
 	if !principal.CanAccess(key.ACL, knox.Read) {
 		return nil, errF(knox.UnauthorizedCode, "")
 	}
+	// Zero ACL for key response, in order to avoid caching unnecessarily
+	key.ACL = knox.ACL{}
 	return key, nil
 }
 
@@ -302,8 +304,8 @@ func putAccessHandler(m KeyManager, principal knox.Principal, parameters map[str
 
 	//Deny addition of ACLS with empty MachinePrefix for Read,Write,and Admin AccessType
 	//Empty MachinePrefix is allowed with None AccessType for revoking existing ACLS
-	if access.Type == knox.MachinePrefix  && access.ID == "" && access.AccessType != knox.None{
-                return nil, errF(knox.BadRequestDataCode,knox.ErrACLEmptyMachinePrefix.Error())
+	if access.Type == knox.MachinePrefix && access.ID == "" && access.AccessType != knox.None {
+		return nil, errF(knox.BadRequestDataCode, knox.ErrACLEmptyMachinePrefix.Error())
 	}
 
 	// Update Access

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -173,6 +173,9 @@ func TestGetKey(t *testing.T) {
 		if k.ID != "a1" {
 			t.Fatalf("Expected ID to be a1 not %s", k.ID)
 		}
+		if len(k.ACL) != 0 {
+			t.Fatalf("Expected key acl to be empty")
+		}
 		if len(k.VersionList) != 1 {
 			t.Fatalf("Expected len to be 1 not %d", len(k.VersionList))
 		}
@@ -189,6 +192,9 @@ func TestGetKey(t *testing.T) {
 		if k.ID != "a1" {
 			t.Fatalf("Expected ID to be a1 not %s", k.ID)
 		}
+		if len(k.ACL) != 0 {
+			t.Fatalf("Expected key acl to be empty")
+		}
 		if len(k.VersionList) != 1 {
 			t.Fatalf("Expected len to be 1 not %d", len(k.VersionList))
 		}
@@ -204,6 +210,9 @@ func TestGetKey(t *testing.T) {
 	case *knox.Key:
 		if k.ID != "a1" {
 			t.Fatalf("Expected ID to be a1 not %s", k.ID)
+		}
+		if len(k.ACL) != 0 {
+			t.Fatalf("Expected key acl to be empty")
 		}
 		if len(k.VersionList) != 1 {
 			t.Fatalf("Expected len to be 1 not %d", len(k.VersionList))
@@ -360,23 +369,23 @@ func TestPutAccess(t *testing.T) {
 		t.Fatalf("%+v is not nil", err)
 	}
 
-	//Tests for setting ACLs with empty machinePrefix  
+	//Tests for setting ACLs with empty machinePrefix
 	//Should return error when used with AccessType Read,Write, or Admin
 	//Should return success when used with AccessType None(useful for revoking such existing ACLs)
-	accessTypes := []knox.AccessType{knox.None,knox.Read,knox.Write,knox.Admin}
-	for  _,accessType := range accessTypes{
-	    access = &knox.Access{Type: knox.MachinePrefix, ID: "", AccessType: accessType}
-	    accessJSON, jerr = json.Marshal(access)
-	    if jerr != nil {
-	    	t.Fatalf("%+v is not nil", jerr)
-	    }
-	    _, err = putAccessHandler(m, u, map[string]string{"keyID": "a1", "access": string(accessJSON)})
-	    if err == nil && accessType != knox.None{
-                  t.Fatal("Expected err") 
-	    } else if err != nil && accessType == knox.None{
-                  t.Fatalf("%+v is not nil",err)
-	    }
-        }
+	accessTypes := []knox.AccessType{knox.None, knox.Read, knox.Write, knox.Admin}
+	for _, accessType := range accessTypes {
+		access = &knox.Access{Type: knox.MachinePrefix, ID: "", AccessType: accessType}
+		accessJSON, jerr = json.Marshal(access)
+		if jerr != nil {
+			t.Fatalf("%+v is not nil", jerr)
+		}
+		_, err = putAccessHandler(m, u, map[string]string{"keyID": "a1", "access": string(accessJSON)})
+		if err == nil && accessType != knox.None {
+			t.Fatal("Expected err")
+		} else if err != nil && accessType == knox.None {
+			t.Fatalf("%+v is not nil", err)
+		}
+	}
 
 }
 


### PR DESCRIPTION
This is not used by the client, and would be entered into the cache. The cache only changes via key data updates (not ACL updates) so it is a bit confusing to have this as part of the cache. GetACL uses a separate endpoint, so this data is totally extraneous.