### PR TITLE
Expose GetParams

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -189,7 +189,7 @@ func writeData(w http.ResponseWriter, data interface{}) {
 func (r route) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	db := getDB(req)
 	principal := GetPrincipal(req)
-	ps := getParams(req)
+	ps := GetParams(req)
 	data, err := r.handler(db, principal, ps)
 
 	if err != nil {

--- a/server/decorators.go
+++ b/server/decorators.go
@@ -45,7 +45,8 @@ func setPrincipal(r *http.Request, val knox.Principal) {
 	context.Set(r, principalContext, val)
 }
 
-func getParams(r *http.Request) map[string]string {
+// GetParams gets the parameters for the request through the parameters context.
+func GetParams(r *http.Request) map[string]string {
 	if rv := context.Get(r, paramsContext); rv != nil {
 		return rv.(map[string]string)
 	}
@@ -95,7 +96,7 @@ func Logger(logger *log.Logger) func(http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			f(w, r)
 			p := GetPrincipal(r)
-			params := getParams(r)
+			params := GetParams(r)
 			apiError := GetAPIError(r)
 			e := &reqLog{
 				Type:       "access",


### PR DESCRIPTION
Expose GetParams to decorators, so that metrics/logging decorators can capture information about e.g. which key was modified.  @krockpot @devinlundberg 