### PR TITLE
Modified Knox Client to include Key Object

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,7 +32,7 @@ type Client interface {
 	// GetActive returns all of the active key versions for the knox key.
 	// This should be used for receiving relationships like verifying or decrypting.
 	GetActive() []string
-	//Get knox Key Object. The Key Object returned can be further used to query versionIDs, ACLs, and other attributes
+	//GetKeyObject returns the full key object, including versions, ACLs, and other attributes.
 	GetKeyObject() Key
 }
 

--- a/client.go
+++ b/client.go
@@ -32,13 +32,16 @@ type Client interface {
 	// GetActive returns all of the active key versions for the knox key.
 	// This should be used for receiving relationships like verifying or decrypting.
 	GetActive() []string
+	//Get knox Key Object. The Key Object returned can be further used to query versionIDs, ACLs, and other attributes
+	GetKeyObject() Key
 }
 
 type fileClient struct {
 	sync.RWMutex
-	keyID   string
-	primary string
-	active  []string
+	keyID     string
+	primary   string
+	active    []string
+	keyObject Key
 }
 
 // update reads the file from a specific location, decodes json, and updates the key in memory.
@@ -60,6 +63,7 @@ func (c *fileClient) update() error {
 func (c *fileClient) setValues(key *Key) {
 	c.Lock()
 	defer c.Unlock()
+	c.keyObject = *key
 	c.primary = string(key.VersionList.GetPrimary().Data)
 	ks := key.VersionList.GetActive()
 	c.active = make([]string, len(ks))
@@ -78,6 +82,13 @@ func (c *fileClient) GetActive() []string {
 	c.RLock()
 	defer c.RUnlock()
 	return c.active
+}
+
+func (c *fileClient) GetKeyObject() Key {
+	c.RLock()
+	defer c.RUnlock()
+	return c.keyObject
+
 }
 
 // NewFileClient creates a file watcher knox client for the keyID given (it refreshes every ten seconds).
@@ -105,9 +116,20 @@ func NewFileClient(keyID string) (Client, error) {
 	return c, nil
 }
 
+//Creates a mockKeyVersion to be used for testing
+func NewMockKeyVersion(keydata []byte, status VersionStatus) KeyVersion {
+	return KeyVersion{Data: keydata, Status: status}
+}
+
 // NewMock is a knox Client to be used for testing.
 func NewMock(primary string, active []string) Client {
-	return &fileClient{primary: primary, active: active}
+	var kvl []KeyVersion
+	kvl = append(kvl, NewMockKeyVersion([]byte(primary), Primary))
+	for _, data := range active {
+		kvl = append(kvl, NewMockKeyVersion([]byte(data), Active))
+	}
+
+	return &fileClient{primary: primary, active: active, keyObject: Key{VersionList: KeyVersionList(kvl)}}
 }
 
 // Register registers the given keyName with knox. If the operation fails, it returns an error.

--- a/client.go
+++ b/client.go
@@ -32,7 +32,7 @@ type Client interface {
 	// GetActive returns all of the active key versions for the knox key.
 	// This should be used for receiving relationships like verifying or decrypting.
 	GetActive() []string
-	//GetKeyObject returns the full key object, including versions, ACLs, and other attributes.
+	// GetKeyObject returns the full key object, including versions, ACLs, and other attributes.
 	GetKeyObject() Key
 }
 
@@ -88,7 +88,6 @@ func (c *fileClient) GetKeyObject() Key {
 	c.RLock()
 	defer c.RUnlock()
 	return c.keyObject
-
 }
 
 // NewFileClient creates a file watcher knox client for the keyID given (it refreshes every ten seconds).
@@ -116,7 +115,7 @@ func NewFileClient(keyID string) (Client, error) {
 	return c, nil
 }
 
-//Creates a mockKeyVersion to be used for testing
+// NewMockKeyVersion creates a Knox KeyVersion to be used for testing
 func NewMockKeyVersion(keydata []byte, status VersionStatus) KeyVersion {
 	return KeyVersion{Data: keydata, Status: status}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"sync/atomic"
 	"testing"
 )
@@ -11,13 +12,16 @@ import (
 func TestMockClient(t *testing.T) {
 	p := "primary"
 	a := []string{"active1", "active2"}
-	k := NewMock(p, a)
-	p1 := k.GetPrimary()
-	//k1 := k.GetKeyObject()
+	k0 := Key{
+		VersionList: []KeyVersion{
+			KeyVersion{Data: []byte(p), Status: Primary}, KeyVersion{Data: []byte(a[0]), Status: Active}, KeyVersion{Data: []byte(a[1]), Status: Active}}}
+
+	m := NewMock(p, a)
+	p1 := m.GetPrimary()
 	if p1 != p {
 		t.Fatalf("Expected %s : Got %s for primary key", p, p1)
 	}
-	r := k.GetActive()
+	r := m.GetActive()
 	if len(r) != len(a) {
 		t.Fatalf("For active keys: length %d should equal length %d", len(r), len(a))
 	}
@@ -26,6 +30,11 @@ func TestMockClient(t *testing.T) {
 			t.Fatalf("%s should equal %s", r[i], a[i])
 		}
 	}
+	k1 := m.GetKeyObject()
+	if !reflect.DeepEqual(k0, k1) {
+		t.Fatalf("Got %v, Want %v", k1, k0)
+	}
+
 }
 
 func buildGoodResponse(data interface{}) ([]byte, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -13,6 +13,7 @@ func TestMockClient(t *testing.T) {
 	a := []string{"active1", "active2"}
 	k := NewMock(p, a)
 	p1 := k.GetPrimary()
+	//k1 := k.GetKeyObject()
 	if p1 != p {
 		t.Fatalf("Expected %s : Got %s for primary key", p, p1)
 	}


### PR DESCRIPTION
Currently, fileClient Object only returns key data. There's no way to retrieve key metadata like Version,ACL, etc using the Client Interface. 

To remediate this problem I propose following changes:
1. adding an additional field called keyObject of type knox.Key to the fileClient struct
2. extending the client interface by adding GetKeyObject method which returns the KeyObject