### PR TITLE
Allow Spiffe Fallback when using MachineAuth

### DIFF
--- a/cmd/dev_server/main.go
+++ b/cmd/dev_server/main.go
@@ -81,6 +81,7 @@ func main() {
 			auth.NewMTLSAuthProvider(certPool),
 			auth.NewGitHubProvider(authTimeout),
 			auth.NewSpiffeAuthProvider(certPool),
+			auth.NewSpiffeAuthFallbackProvider(certPool),
 		}),
 	}
 

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -146,9 +146,21 @@ type SpiffeFallbackProvider struct {
 	SpiffeProvider
 }
 
+// NewSpiffeAuthFallbackProvider initializes a chain of trust with given CA certificates,
+// identical to the SpiffeProvider except the Type is defined as the MTLSAuthProvider
+// Type().
+func NewSpiffeAuthFallbackProvider(CAs *x509.CertPool) *SpiffeFallbackProvider {
+	return &SpiffeFallbackProvider{
+		SpiffeProvider: SpiffeProvider{
+			CAs:  CAs,
+			time: time.Now,
+		},
+	}
+}
+
 // Type is set to be identical to the Type of the MTLSAuthProvider
-func (s *SpiffeFallbackProvider) Type() {
-	return MTLSAuthProvider{}.Type()
+func (s *SpiffeFallbackProvider) Type() byte {
+	return (&MTLSAuthProvider{}).Type()
 }
 
 // GitHubProvider implements user authentication through github.com

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -135,6 +135,22 @@ func (p *SpiffeProvider) Authenticate(token string, r *http.Request) (knox.Princ
 	return NewService(splits[0], splits[1]), nil
 }
 
+// SpiffeFallbackProvider is a SpiffeProvider that uses the same Type byte as the
+// MTLSAuthProvider. The use case for this is to allow a client that specifies
+// MTLSAuth to also transparently be given Spiffe based access as well. For
+// more predictable results, ensure that the MTLSAuthProvider is registered before
+// the SpiffeFallbackProvider so that MTLSAuthProvider is always used if it succeeds.
+// Note that this is only possible with the SpiffeProvider because there is no use
+// of the token from the AuthorizationHeader in this Provider.
+type SpiffeFallbackProvider struct {
+	SpiffeProvider
+}
+
+// Type is set to be identical to the Type of the MTLSAuthProvider
+func (s *SpiffeFallbackProvider) Type() {
+	return MTLSAuthProvider{}.Type()
+}
+
 // GitHubProvider implements user authentication through github.com
 type GitHubProvider struct {
 	client httpClient


### PR DESCRIPTION
This will allow any client making a request with machine auth, that
also has a Spiffe that has access to the key in question, and their
machine auth does not grant access, to use that Spiffe access to
grant the key.

To put another way:
Machine A wants to read Key K.
Machine A has Spiffe Alpha.
Key K has granted read access only to Spiffe Alpha.
Machine A sends a request using the Authorization Header "0tAlice"
The MTLSAuthProvider will look at this request and say, Alice does
not have access to key K. Please try another provider.
The SpiffeAuthProvider will look at this request and say "0t" is not
"0s" so I cannot act on this request.
The new SpiffeAuthFallbackProvider will look at this request and
say "0t" I can try that. Then it ignores the Alice part of the header
and runs the SpiffeAuth check to see that Alpha has in fact been
granted access to Key K, and this key should be returned.