### PR TITLE
Support service prefix matching and validation

### DIFF
--- a/client/updateaccess.go
+++ b/client/updateaccess.go
@@ -25,7 +25,8 @@ Access will add or change the acl on a key by adding a specific access control r
 -U: A specific user. The principal should be set to the ldap username of the user.
 -G: A specific user group. The principal should be set to the group name. This takes the format of ou=Security,ou=Prod,ou=groups,dc=pinterest,dc=com in LDAP.
 -P: A machine hostname prefix. Prefix matching will be used to determine access. For example, if the principal is set to 'auth' then 'auth004' would match (and so would any hostname beginning with auth).
--S: A specific service. The principal should be set to the exact Spiffe ID. For example, spiffe://example.com/service
+-S: A specific service. The principal should be set to the exact SPIFFE ID. For example, 'spiffe://example.com/service'.
+-N: A service prefix (namespace). The principal should be set to a SPIFFE ID ending with a slash, such as 'spiffe://example.com/namespace/'. This will match all services under that prefix, so for example 'spiffe://example.com/namespace/service' would be allowed.
 
 This command requires admin access to the key.
 
@@ -45,6 +46,7 @@ var updateAccessUser = cmdUpdateAccess.Flag.Bool("U", false, "")
 var updateAccessGroup = cmdUpdateAccess.Flag.Bool("G", false, "")
 var updateAccessPrefix = cmdUpdateAccess.Flag.Bool("P", false, "")
 var updateAccessService = cmdUpdateAccess.Flag.Bool("S", false, "")
+var updateAccessServicePrefix = cmdUpdateAccess.Flag.Bool("N", false, "")
 
 func runUpdateAccess(cmd *Command, args []string) {
 	if len(args) != 2 {
@@ -77,8 +79,10 @@ func runUpdateAccess(cmd *Command, args []string) {
 		access.Type = knox.MachinePrefix
 	case *updateAccessService:
 		access.Type = knox.Service
+	case *updateAccessServicePrefix:
+		access.Type = knox.ServicePrefix
 	default:
-		fatalf("access requires {-M|-U|-G|-P|-S}. See 'knox help access'")
+		fatalf("access requires {-M|-U|-G|-P|-S|-N}. See 'knox help access'")
 	}
 	err := cli.PutAccess(keyID, &access)
 	if err != nil {

--- a/server/api.go
+++ b/server/api.go
@@ -45,6 +45,7 @@ var HTTPErrMap = map[int]*httpErrResp{
 	knox.NoKeyDataCode:                 &httpErrResp{http.StatusBadRequest, "Missing Key Data"},
 	knox.BadRequestDataCode:            &httpErrResp{http.StatusBadRequest, "Bad request format"},
 	knox.BadKeyFormatCode:              &httpErrResp{http.StatusBadRequest, "Key ID contains unsupported characters"},
+	knox.BadPrincipalIdentifier:        &httpErrResp{http.StatusBadRequest, "Invalid principal identifier"},
 }
 
 func combine(f, g func(http.HandlerFunc) http.HandlerFunc) func(http.HandlerFunc) http.HandlerFunc {
@@ -206,6 +207,16 @@ var defaultAccess []knox.Access
 // AddDefaultAccess adds an access to every created key.
 func AddDefaultAccess(a *knox.Access) {
 	defaultAccess = append(defaultAccess, *a)
+}
+
+// Extra validators to apply on principals submitted to Knox.
+var extraPrincipalValidators []knox.PrincipalValidator
+
+// AddPrincipalValidator applies additional, custom validation on principals
+// submitted to Knox for adding into ACLs. Can be used to set custom business
+// logic for e.g. what kind of machine or service prefixes are acceptable.
+func AddPrincipalValidator(validator knox.PrincipalValidator) {
+	extraPrincipalValidators = append(extraPrincipalValidators, validator)
 }
 
 // newKeyVersion creates a new KeyVersion with correctly set defaults.

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -352,6 +352,10 @@ func (s service) CanAccess(acl knox.ACL, t knox.AccessType) bool {
 			if a.ID == string(s.GetID()) && a.AccessType.CanAccess(t) {
 				return true
 			}
+		case knox.ServicePrefix:
+			if strings.HasPrefix(s.GetID(), a.ID) && a.AccessType.CanAccess(t) {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
This is similar to machine prefix matching, but for services. In addition to adding the new PrincipalType this also expands the validation for principals and adds support for custom validation logic that can be applied using custom validators. We previously only validated machine prefixes, but now we also validate services and service prefixes to make sure they conform the proper format.