### PR TITLE
Add Principal Mux to hold multiple principals

### DIFF
--- a/knox.go
+++ b/knox.go
@@ -508,6 +508,45 @@ type Principal interface {
 	GetID() string
 }
 
+// PrincipalMux provides a Principal Interface over multiple Principals.
+type PrincipalMux struct {
+	principals []Principal
+}
+
+// CanAccess will check the principals in order of adding, and the first
+// Principal that provides at least the AccessType requested will be used.
+func (p PrincipalMux) CanAccess(acl ACL, accessType AccessType) bool {
+	for _, p := range p.principals {
+		if p.CanAccess(acl, accessType) {
+			return true
+		}
+	}
+	return false
+}
+
+// GetID returns the first registered ID.
+func (p PrincipalMux) GetID() string {
+	if len(p.principals) == 0 {
+		return "No Principal Found"
+	}
+	return p.principals[0].GetID()
+}
+
+// Default returns the first registered Principal.
+func (p PrincipalMux) Default() Principal {
+	if len(p.principals) == 0 {
+		return nil
+	}
+	return p.principals[0]
+}
+
+// NewPrincipalMux returns a Principal that represents many principals.
+func NewPrincipalMux(p []Principal) Principal {
+	return PrincipalMux{
+		principals: p,
+	}
+}
+
 // These are the error codes for use in server responses.
 const (
 	OKCode = iota

--- a/knox.go
+++ b/knox.go
@@ -541,7 +541,7 @@ func (p PrincipalMux) Default() Principal {
 }
 
 // NewPrincipalMux returns a Principal that represents many principals.
-func NewPrincipalMux(p []Principal) Principal {
+func NewPrincipalMux(p Principal...) Principal {
 	return PrincipalMux{
 		principals: p,
 	}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -232,7 +232,7 @@ type httpClient interface {
 	Do(req *http.Request) (resp *http.Response, err error)
 }
 
-// IsUser returns true if the principal is a user.
+// IsUser returns true if the principal, or first principal in the case of mux, is a user.
 func IsUser(p knox.Principal) bool {
 	if mux, ok := p.(knox.PrincipalMux); ok {
 		p = mux.Default()
@@ -241,7 +241,7 @@ func IsUser(p knox.Principal) bool {
 	return ok
 }
 
-// IsService returns true if the principal is a service.
+// IsService returns true if the principal, or first principal in the case of mux, is a service.
 func IsService(p knox.Principal) bool {
 	if mux, ok := p.(knox.PrincipalMux); ok {
 		p = mux.Default()

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -234,12 +234,18 @@ type httpClient interface {
 
 // IsUser returns true if the principal is a user.
 func IsUser(p knox.Principal) bool {
+	if mux, ok := p.(knox.PrincipalMux); ok {
+		p = mux.Default()
+	}
 	_, ok := p.(user)
 	return ok
 }
 
 // IsService returns true if the principal is a service.
 func IsService(p knox.Principal) bool {
+	if mux, ok := p.(knox.PrincipalMux); ok {
+		p = mux.Default()
+	}
 	_, ok := p.(service)
 	return ok
 }

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -95,6 +95,26 @@ func TestServiceCanAccess(t *testing.T) {
 	}
 }
 
+func TestPrincipalMuxUserOrService(t *testing.T) {
+	u := NewUser("test", []string{"returntrue"})
+	s := NewService("example.com", "serviceA")
+	userMux := knox.NewPrincipalMux(u, s)
+	serviceMux := knox.NewPrincipalMux(s, u)
+
+	if !IsUser(userMux) {
+		t.Error("IsUser failed to identify that mux is user first.")
+	}
+	if IsService(userMux) {
+		t.Error("IsService failed to identify that mux is user first, and thus not a service.")
+	}
+	if IsUser(serviceMux) {
+		t.Error("IsUser failed to identify that mux is service first, and thus not a user.")
+	}
+	if !IsService(serviceMux) {
+		t.Error("IsService failed to identify that mux is service first.")
+	}
+}
+
 const caCert = `-----BEGIN CERTIFICATE-----
 MIICOjCCAeCgAwIBAgIUIKkBZQbtx8rVaWIOhpabkqZSqecwCgYIKoZIzj0EAwIw
 aTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNh

--- a/server/decorators.go
+++ b/server/decorators.go
@@ -211,7 +211,7 @@ func Authentication(providers []auth.Provider) func(http.HandlerFunc) http.Handl
 				return
 			}
 
-			setPrincipal(r, knox.NewPrincipalMux(principals))
+			setPrincipal(r, knox.NewPrincipalMux(...principals))
 			f(w, r)
 			return
 		}


### PR DESCRIPTION
This way the Authentication middleware can provide the mux of all
valid principals that can be constructed. Then the downstream handler
that checks CanAccess on that set of principals can check each one
and allow access if any of them would grant access.

This is really only possible because of the SpiffeFallbackProvider,
because the only way that a call could have two valid Principals
is if you are using that provider as well as the MachineAuth provider.

I wrestled with where this mux should be defined. Particularly because
of the changes needed in auth.go to support type inspection into the
mux for IsService and IsUser. Ultimately, I concluded that it belonged
next to the Principal interface itself as that is the only thing that
it is actually dependent on.

The overall goal is to provide access to keys by either machine or
service auth so that we can begin granting key privileges using service
without having to move all keys over whole sale.

More tests will also be forth coming.