### PR TITLE
Add debug logging for lock timeouts

### DIFF
--- a/client/daemon.go
+++ b/client/daemon.go
@@ -3,11 +3,14 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"os/exec"
 	"path"
+	"runtime"
 	"strings"
 	"time"
 
@@ -292,12 +295,33 @@ func NewKeysFile(fn string) Keys {
 
 // Lock performs the nonblocking syscall lock and retries until the global timeout is met.
 func (k *KeysFile) Lock() error {
-	return k.lock(k, defaultFilePermission, true, lockTimeout)
+	err := k.lock(k, defaultFilePermission, true, lockTimeout)
+
+	// Timeout means someone else is using our lock, which is unusual.
+	// Let's collect some extra debugging information to find out why.
+	if err == ErrTimeout && runtime.GOOS == "linux" {
+		lockHolders, err := identifyLockHolders(k.fn)
+		if err != nil {
+			logf("hit timeout, found lock holder information:\n%s", lockHolders)
+		}
+	}
+
+	// Annotate error with path to file to make debugging easier
+	if err != nil {
+		return fmt.Errorf("unable to obtain lock on file '%s': %w", k.fn, err)
+	}
+	return nil
 }
 
 // Unlock performs the nonblocking syscall unlock and retries until the global timeout is met.
 func (k *KeysFile) Unlock() error {
-	return k.unlock(k)
+	err := k.unlock(k)
+
+	// Annotate error with path to file to make debugging easier
+	if err != nil {
+		return fmt.Errorf("unable to release lock on file '%s': %w", k.fn, err)
+	}
+	return nil
 }
 
 // Get will get the list of key ids. It expects Lock to have been called.
@@ -388,4 +412,18 @@ func (k *KeysFile) Overwrite(ks []string) error {
 		buffer.WriteByte('\n')
 	}
 	return ioutil.WriteFile(k.fn, buffer.Bytes(), 0666)
+}
+
+func identifyLockHolders(filename string) (string, error) {
+	if runtime.GOOS != "linux" {
+		return "", errors.New("error identifying lock holder: works only on linux")
+	}
+
+	cmd := exec.Command("lsof", filename)
+	stdout, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("error identifying lock holder: %w", err)
+	}
+
+	return string(stdout), nil
 }

--- a/client/daemon_test.go
+++ b/client/daemon_test.go
@@ -6,8 +6,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
+	"path"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pinterest/knox"
 )
@@ -550,4 +555,58 @@ func TestBackwardsCompat(t *testing.T) {
 			t.Fatalf("%s does not equal 1, 2, or 3", key)
 		}
 	}
+}
+
+func TestLockTimeout(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Test must run on Linux")
+		return
+	}
+
+	tmp, err := ioutil.TempDir("", "test-lock-timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	lockFile := path.Join(tmp, "lock")
+	ioutil.WriteFile(lockFile, []byte{}, 0600)
+
+	// Lock file in sub-process to create locking conflict
+	lockingSubprocess := lockFileInSeparateProcess(t, lockFile, "300")
+	defer func() {
+		if lockingSubprocess.Process != nil {
+			lockingSubprocess.Process.Kill()
+		}
+	}()
+
+	// Wait for subprocess to spin up
+	time.Sleep(5 * time.Second)
+
+	// Dump lock holder pre-timeout (useful to identify test failures)
+	t.Log(identifyLockHolders(lockFile))
+
+	// Try to acquire lock in this process and make sure we hit a timeout
+	kf := NewKeysFile(lockFile)
+	err = kf.Lock()
+	if err == nil {
+		t.Fatal("was able to acquire lock, but should not have been")
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Fatal("got lock error, but error was not a timeout")
+	}
+
+	// Dump lock holder post-timeout (useful to identify test failures)
+	t.Log(identifyLockHolders(lockFile))
+}
+
+func lockFileInSeparateProcess(t *testing.T, filename, seconds string) *exec.Cmd {
+	// Spawn "flock" subprocess that will acquire and hold lock for us (up to N seconds)
+	cmd := exec.Command("flock", "-F", filename, "sleep", seconds)
+	err := cmd.Start()
+	if err != nil {
+		t.Fatal(err)
+		return nil
+	}
+	return cmd
 }

--- a/client/flock_unix.go
+++ b/client/flock_unix.go
@@ -14,7 +14,7 @@ import (
 
 // ErrTimeout is returned when we cannot obtain an exclusive lock
 // on the key file.
-var ErrTimeout = errors.New("timeout")
+var ErrTimeout = errors.New("timeout waiting on lock to become available")
 
 type flock struct {
 	fd int

--- a/client/flock_windows.go
+++ b/client/flock_windows.go
@@ -19,7 +19,7 @@ var (
 
 	// ErrTimeout is returned when we cannot obtain an exclusive lock
 	// on the key file.
-	ErrTimeout = errors.New("timeout")
+	ErrTimeout = errors.New("timeout waiting on lock to become available")
 )
 
 const (

--- a/client/register.go
+++ b/client/register.go
@@ -61,7 +61,7 @@ func runRegister(cmd *Command, args []string) {
 
 	err = k.Lock()
 	if err != nil {
-		fatalf("There was an error getting file lock %s", err.Error())
+		fatalf("There was an error obtaining file lock: %s", err.Error())
 	}
 	if *registerRemove {
 		err = k.Overwrite(ks)


### PR DESCRIPTION
Print additional debug info when we see lock acquisition timing out to
allow users to see what's causing the timeout. We want this to happen in
the process to make sure we have the right view of the filesystem and
can capture the information in the right moment. If we leave this up to
users it becomes tough to debug, as by the time a user remotes into the
machine the conflict is probably already resolved.

Example test run:
```
=== RUN   TestLockTimeout
    TestLockTimeout: daemon_test.go:587: COMMAND   PID   USER   FD   TYPE DEVICE SIZE/OFF    NODE NAME
        sleep   15210 cstaub    3rW  REG  259,1        0 3602634 /tmp/test-lock-timeout363431601/lock
         <nil>
    TestLockTimeout: daemon_test.go:600: COMMAND     PID   USER   FD   TYPE DEVICE SIZE/OFF    NODE NAME
        client.te 15205 cstaub    7u   REG  259,1        0 3602634 /tmp/test-lock-timeout363431601/lock
        sleep     15210 cstaub    3rW  REG  259,1        0 3602634 /tmp/test-lock-timeout363431601/lock
         <nil>
--- PASS: TestLockTimeout (15.41s)
```

Note that "sleep" has the lock on the file, denoted by the "W" in the FD column.