### PR TITLE
Fix behavior of CLI to get versions with status

### DIFF
--- a/client/getversions.go
+++ b/client/getversions.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -12,12 +13,13 @@ func init() {
 }
 
 var cmdGetVersions = &Command{
-	UsageLine: "versions [-s state] <key_identifier>",
+	UsageLine: "versions [-s state] [-v] <key_identifier>",
 	Short:     "gets the versions for a key",
 	Long: `
 versions get all of the version ids for a key.
 
 -s specifies the minimum state of key to return. By default this is set to active which means active and primary keys are returned. Accepted values include inactive, active, and primary.
+-v enables verbose output, which shows the state of each version alongside the version number.
 
 This requires read access to the key and can use user or machine authentication.
 
@@ -27,6 +29,7 @@ See also: knox keys, knox get
 	`,
 }
 var getVersionsState = cmdGetVersions.Flag.String("s", "active", "")
+var verboseOutput = cmdGetVersions.Flag.Bool("v", false, "verbose")
 
 func runGetVersions(cmd *Command, args []string) {
 	if len(args) != 1 {
@@ -50,6 +53,14 @@ func runGetVersions(cmd *Command, args []string) {
 	}
 	kvl := key.VersionList
 	for _, v := range kvl {
-		fmt.Printf("%d\n", v.ID)
+		status, err := json.Marshal(v.Status)
+		if err != nil {
+			status = []byte("(unknown)")
+		}
+		if *verboseOutput {
+			fmt.Printf("%d %s\n", v.ID, string(status))
+		} else {
+			fmt.Printf("%d\n", v.ID)
+		}
 	}
 }

--- a/client/getversions.go
+++ b/client/getversions.go
@@ -26,29 +26,29 @@ For more about knox, see https://github.com/pinterest/knox.
 See also: knox keys, knox get
 	`,
 }
-var getVersionsState = cmdGetVersions.Flag.String("s", "ACTIVE", "")
+var getVersionsState = cmdGetVersions.Flag.String("s", "active", "")
 
 func runGetVersions(cmd *Command, args []string) {
 	if len(args) != 1 {
 		fatalf("get takes only one argument. See 'knox help versions'")
 	}
 
+	var status knox.VersionStatus
+	switch strings.ToLower(*getVersionsState) {
+	case "active":
+		status = knox.Active
+	case "primary":
+		status = knox.Primary
+	case "inactive":
+		status = knox.Inactive
+	}
+
 	keyID := args[0]
-	key, err := cli.GetKey(keyID)
+	key, err := cli.GetKeyWithStatus(keyID, status)
 	if err != nil {
 		fatalf("Error getting key: %s", err.Error())
 	}
-	var kvl knox.KeyVersionList
-	switch strings.ToLower(*getVersionsState) {
-	case "active":
-		kvl = key.VersionList.GetActive()
-	case "inactive":
-		kvl = key.VersionList
-	case "primary":
-		kvl = knox.KeyVersionList{*key.VersionList.GetPrimary()}
-	default:
-		fatalf("Invalid status parameter: %s", *getVersionsState)
-	}
+	kvl := key.VersionList
 	for _, v := range kvl {
 		fmt.Printf("%d\n", v.ID)
 	}


### PR DESCRIPTION
Right now, if get versions is called with the -s inactive flag Knox it
will still only print active key versions. This is because the backend
assumes the version status to be "Active" by default when "get key" is
called. To get inactive versions, we have to pass the status flag to the
backend otherwise inactive versions will not be visible.