### PR TITLE
Add -a flag to let `knox get` return all key versions

### DIFF
--- a/client/get.go
+++ b/client/get.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 var cmdGet = &Command{
-	UsageLine: "get [-v key_version] [-n] [-j] <key_identifier>",
+	UsageLine: "get [-v key_version] [-n] [-j] [-a] <key_identifier>",
 	Short:     "get a knox key",
 	Long: `
 Get gets the key data for a key.
@@ -21,6 +21,7 @@ Get gets the key data for a key.
 -v specifies the key_version to get. If it is not provided, this returns the most recent version.
 -j returns the json version of the key as specified in the knox API.
 -n forces a network call. This will avoid cache issues where the ACL is out of date.
+-a returns all key versions (including inactive ones). Only works when -j is specified.
 
 This requires read access to the key.
 
@@ -32,6 +33,7 @@ See also: knox create, knox daemon, knox register, knox keys
 var getVersion = cmdGet.Flag.String("v", "", "")
 var getJSON = cmdGet.Flag.Bool("j", false, "")
 var getNetwork = cmdGet.Flag.Bool("n", false, "")
+var getAll = cmdGet.Flag.Bool("a", false, "")
 
 func runGet(cmd *Command, args []string) {
 	if len(args) != 1 {
@@ -41,10 +43,20 @@ func runGet(cmd *Command, args []string) {
 
 	var err error
 	var key *knox.Key
-	if *getNetwork {
-		key, err = cli.NetworkGetKey(keyID)
+	if *getAll {
+		// By specifying status as inactive, we can get all key versions (active + inactive + primary)
+		// from knox server
+		if *getNetwork {
+			key, err = cli.NetworkGetKeyWithStatus(keyID, knox.Inactive)
+		} else {
+			key, err = cli.GetKeyWithStatus(keyID, knox.Inactive)
+		}
 	} else {
-		key, err = cli.GetKey(keyID)
+		if *getNetwork {
+			key, err = cli.NetworkGetKey(keyID)
+		} else {
+			key, err = cli.GetKey(keyID)
+		}
 	}
 	if err != nil {
 		fatalf("Error getting key: %s", err.Error())


### PR DESCRIPTION
@csstaub added two methods `NetworkGetKeyWithStatus` and `GetKeyWithStatus` (as well as tests) in
https://github.com/pinterest/knox/commit/5184b07043b7f6c84deeffbf56a194d74d9294f9

This change allows users to get all key versions (including inactive ones) as a JSON blob. Existing uses of `knox get -j` won't be affected.