### PR TITLE
return full error message to client

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -156,7 +156,7 @@ func writeErr(apiErr *httpError) http.HandlerFunc {
 		resp.Timestamp = time.Now().UnixNano()
 		resp.Status = "error"
 		resp.Code = apiErr.Subcode
-		resp.Message = HTTPErrMap[apiErr.Subcode].Message
+		resp.Message = apiErr.Message
 		code := HTTPErrMap[apiErr.Subcode].Code
 		w.WriteHeader(code)
 		setAPIError(r, apiErr)


### PR DESCRIPTION
the error messages passed to the client can be pretty vague and don't always make it clear to the user what the issue was. By passing back the full message, users will be able to more quickly understand issues with their requests.