### PR TITLE
Add support for multi-value update access commands

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build
-      run: go build -v .
+      run: go build -v ./...
 
     - name: Test
-      run: go test -v .
+      run: go test -v ./...

--- a/client.go
+++ b/client.go
@@ -160,7 +160,7 @@ type APIClient interface {
 	GetKeys(keys map[string]string) ([]string, error)
 	DeleteKey(keyID string) error
 	GetACL(keyID string) (*ACL, error)
-	PutAccess(keyID string, a *Access) error
+	PutAccess(keyID string, acl ...Access) error
 	AddVersion(keyID string, data []byte) (uint64, error)
 	UpdateVersion(keyID, versionID string, status VersionStatus) error
 	CacheGetKey(keyID string) (*Key, error)
@@ -321,13 +321,13 @@ func (c *HTTPClient) GetACL(keyID string) (*ACL, error) {
 }
 
 // PutAccess will add an ACL rule to a specific key.
-func (c *HTTPClient) PutAccess(keyID string, a *Access) error {
+func (c *HTTPClient) PutAccess(keyID string, a ...Access) error {
 	d := url.Values{}
 	s, err := json.Marshal(a)
 	if err != nil {
 		return err
 	}
-	d.Set("access", string(s))
+	d.Set("acl", string(s))
 	err = c.getHTTPData("PUT", "/v0/keys/"+keyID+"/access/", d, nil)
 	return err
 }

--- a/client/updateaccess.go
+++ b/client/updateaccess.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/pinterest/knox"
 )
@@ -11,7 +13,7 @@ func init() {
 }
 
 var cmdUpdateAccess = &Command{
-	UsageLine: "access {-n|-r|-w|-a} {-M|-U|-G|-P} <key_identifier> <principal>",
+	UsageLine: "access (-acl <file> <key_identifier> | {-n|-r|-w|-a} {-M|-U|-G|-P} <key_identifier> <principal>)",
 	Short:     "access modifies the acl of a key",
 	Long: `
 Access will add or change the acl on a key by adding a specific access control rule.
@@ -36,6 +38,8 @@ See also: knox create, knox get
 	`,
 }
 
+var updateAccessACL = cmdUpdateAccess.Flag.String("acl", "", "")
+
 var updateAccessNone = cmdUpdateAccess.Flag.Bool("n", false, "")
 var updateAccessRead = cmdUpdateAccess.Flag.Bool("r", false, "")
 var updateAccessWrite = cmdUpdateAccess.Flag.Bool("w", false, "")
@@ -49,6 +53,26 @@ var updateAccessService = cmdUpdateAccess.Flag.Bool("S", false, "")
 var updateAccessServicePrefix = cmdUpdateAccess.Flag.Bool("N", false, "")
 
 func runUpdateAccess(cmd *Command, args []string) {
+	if *updateAccessACL != "" {
+		if len(args) != 1 {
+			fatalf("access takes exactly one arguments. See 'knox help access'")
+		}
+		keyID := args[0]
+		b, err := ioutil.ReadFile(*updateAccessACL)
+		if err != nil {
+			fatalf("Could not read acl file %s", err.Error())
+		}
+		acl := []knox.Access{}
+		err = json.Unmarshal(b, &acl)
+		if err != nil {
+			fatalf("Could not decode access list properly %s", err.Error())
+		}
+		err = cli.PutAccess(keyID, acl...)
+		if err != nil {
+			fatalf("Failed to update access: %s", err.Error())
+		}
+		fmt.Println("Successfully updated Access")
+	}
 	if len(args) != 2 {
 		fatalf("access takes exactly two arguments. See 'knox help access'")
 	}
@@ -84,7 +108,7 @@ func runUpdateAccess(cmd *Command, args []string) {
 	default:
 		fatalf("access requires {-M|-U|-G|-P|-S|-N}. See 'knox help access'")
 	}
-	err := cli.PutAccess(keyID, &access)
+	err := cli.PutAccess(keyID, access)
 	if err != nil {
 		fatalf("Failed to update access: %s", err.Error())
 	}

--- a/client/updateaccess.go
+++ b/client/updateaccess.go
@@ -18,6 +18,8 @@ var cmdUpdateAccess = &Command{
 	Long: `
 Access will add or change the acl on a key by adding a specific access control rule.
 
+-acl: Takes in a filename with a JSON formatted list of access rules
+
 -n: This will update the key so that the given principal has no access. Please note that if there is another rule that gives access that will take precedence.
 -r: This will grant the principal read access to the key. They will be able to read the keys data.
 -w: This will grant the principal write access to the key. They will be able to rotate keys in addition to all read permissions.
@@ -72,6 +74,7 @@ func runUpdateAccess(cmd *Command, args []string) {
 			fatalf("Failed to update access: %s", err.Error())
 		}
 		fmt.Println("Successfully updated Access")
+		return
 	}
 	if len(args) != 2 {
 		fatalf("access takes exactly two arguments. See 'knox help access'")

--- a/client/updateaccess.go
+++ b/client/updateaccess.go
@@ -57,7 +57,7 @@ var updateAccessServicePrefix = cmdUpdateAccess.Flag.Bool("N", false, "")
 func runUpdateAccess(cmd *Command, args []string) {
 	if *updateAccessACL != "" {
 		if len(args) != 1 {
-			fatalf("access takes exactly one arguments. See 'knox help access'")
+			fatalf("access takes one argument when used with --acl. See 'knox help access'")
 		}
 		keyID := args[0]
 		b, err := ioutil.ReadFile(*updateAccessACL)

--- a/client_test.go
+++ b/client_test.go
@@ -322,7 +322,7 @@ func TestPutAccess(t *testing.T) {
 			t.Fatalf("%s is not %s", r.URL.Path, "/v0/keys/testkey/access/")
 		}
 		r.ParseForm()
-		if r.PostForm["access"][0] == "" {
+		if r.PostForm["acl"][0] == "" {
 			t.Fatalf("%s is empty", r.PostForm["access"][0])
 		}
 	})
@@ -330,13 +330,13 @@ func TestPutAccess(t *testing.T) {
 
 	cli := MockClient(srv.Listener.Addr().String())
 
-	a := &Access{
+	a := Access{
 		Type:       User,
 		AccessType: Read,
 		ID:         "test",
 	}
 
-	badA := &Access{
+	badA := Access{
 		Type:       233,
 		AccessType: 80927,
 		ID:         "test",

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -146,7 +146,7 @@ func checkinternalServerErrorResponse(t *testing.T, w *httptest.ResponseRecorder
 	if resp.Code != knox.InternalServerErrorCode {
 		t.Fatal("unexpected error code")
 	}
-	if resp.Message != HTTPErrMap[knox.InternalServerErrorCode].Message {
+	if resp.Message != "" {
 		t.Fatal("Wrong message")
 	}
 	if resp.Host == "" {

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -473,10 +473,10 @@ func TestKeyAccessUpdatesWithPrincipalValidation(t *testing.T) {
 
 	// Should be *not valid* for user with bad id
 	access = knox.Access{ID: invalidPrincipalID, Type: knox.User, AccessType: knox.Read}
-	putAccessExpectedFailure(t, keyID, &access, "Invalid principal identifier")
+	putAccessExpectedFailure(t, keyID, &access, "Invalid user: "+invalidPrincipalID)
 
 	// Should be *not valid* for user service with bad SPIFFE ID, even though
 	// we don't have a special extra validator for it (validation is built-in)
 	access = knox.Access{ID: "https://ahoy", Type: knox.Service, AccessType: knox.Read}
-	putAccessExpectedFailure(t, keyID, &access, "Invalid principal identifier")
+	putAccessExpectedFailure(t, keyID, &access, "Service prefix is invalid URL, must conform to 'spiffe://<domain>/<path>/' format.")
 }

--- a/server/key_manager.go
+++ b/server/key_manager.go
@@ -14,7 +14,7 @@ type KeyManager interface {
 	GetKey(id string, status knox.VersionStatus) (*knox.Key, error)
 	AddNewKey(*knox.Key) error
 	DeleteKey(id string) error
-	UpdateAccess(string, knox.Access) error
+	UpdateAccess(string, ...knox.Access) error
 	AddVersion(string, *knox.KeyVersion) error
 	UpdateVersion(keyID string, versionID uint64, s knox.VersionStatus) error
 }
@@ -93,14 +93,15 @@ func (m *keyManager) DeleteKey(id string) error {
 	return m.db.Remove(id)
 }
 
-func (m *keyManager) UpdateAccess(id string, a knox.Access) error {
+func (m *keyManager) UpdateAccess(id string, acl ...knox.Access) error {
 	encK, err := m.db.Get(id)
 	if err != nil {
 		return err
 	}
 	newEncK := encK.Copy()
-
-	newEncK.ACL = newEncK.ACL.Add(a)
+	for _, a := range acl {
+		newEncK.ACL = newEncK.ACL.Add(a)
+	}
 	err = newEncK.ACL.Validate()
 	if err != nil {
 		return err

--- a/server/key_manager_test.go
+++ b/server/key_manager_test.go
@@ -245,6 +245,8 @@ func TestUpdateAccess(t *testing.T) {
 	m, u, acl := GetMocks()
 	key1 := newKey("id1", acl, []byte("data"), u)
 	access := knox.Access{Type: knox.User, ID: "grootan", AccessType: knox.Read}
+	access2 := knox.Access{Type: knox.UserGroup, ID: "group", AccessType: knox.Write}
+	access3 := knox.Access{Type: knox.Machine, ID: "machine", AccessType: knox.Read}
 	err := m.UpdateAccess(key1.ID, access)
 	if err == nil {
 		t.Fatal("Should be an error")
@@ -259,19 +261,45 @@ func TestUpdateAccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s is not nil", err)
 	}
+	err = m.UpdateAccess(key1.ID, access2, access3)
+	if err != nil {
+		t.Fatalf("%s is not nil", err)
+	}
 
 	key, err := m.GetKey(key1.ID, knox.Active)
 	if err != nil {
 		t.Fatalf("%s is not nil", err)
 	}
+	if len(key.ACL) != 4 {
+		t.Fatalf("%d acl rules instead of expected 4", len(key.ACL))
+	}
 	for _, a := range key.ACL {
-		if a.ID == access.ID {
+		switch a.ID {
+		case access.ID:
 			if access.Type != a.Type {
 				t.Fatalf("%d does not equal %d", access.Type, a.Type)
 			}
 			if access.AccessType != a.AccessType {
 				t.Fatalf("%d does not equal %d", access.AccessType, a.AccessType)
 			}
+		case access2.ID:
+			if access2.Type != a.Type {
+				t.Fatalf("%d does not equal %d", access2.Type, a.Type)
+			}
+			if access2.AccessType != a.AccessType {
+				t.Fatalf("%d does not equal %d", access2.AccessType, a.AccessType)
+			}
+		case access3.ID:
+			if access3.Type != a.Type {
+				t.Fatalf("%d does not equal %d", access3.Type, a.Type)
+			}
+			if access3.AccessType != a.AccessType {
+				t.Fatalf("%d does not equal %d", access3.AccessType, a.AccessType)
+			}
+		case u.GetID():
+			continue
+		default:
+			t.Fatalf("unknown acl value for key %v", a)
 		}
 	}
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -68,6 +68,7 @@ var routes = [...]route{
 		parameters: []parameter{
 			urlParameter("keyID"),
 			postParameter("access"),
+			postParameter("acl"),
 		},
 	},
 	route{
@@ -264,28 +265,43 @@ func getAccessHandler(m KeyManager, principal knox.Principal, parameters map[str
 
 // putAccessHandler adds or updates the existing ACL with an Access object
 // This object is input as base64 encoded json encoded form data
+// access is used for a single access rule and acl is used for multiple rules
+// existing access rules will not be modified unless the same Type and Name is used
 // The route for this handler is PUT /v0/keys/<key_id>/access/
 // The principal needs Admin access.
 func putAccessHandler(m KeyManager, principal knox.Principal, parameters map[string]string) (interface{}, *httpError) {
 	keyID := parameters["keyID"]
 
 	accessStr, accessOK := parameters["access"]
-	if !accessOK {
-		return nil, errF(knox.BadRequestDataCode, "")
-	}
-	access := knox.Access{}
+	aclStr, aclOK := parameters["acl"]
 
-	// If JSON decode fails, try a base64 encoded JSON string (both options are around for backwards compatibility)
-	jsonErr := json.Unmarshal([]byte(accessStr), &access)
-	if jsonErr != nil {
-		decodedData, decodeErr := base64.RawURLEncoding.DecodeString(accessStr)
+	acl := []knox.Access{}
+	if accessOK {
+		access := knox.Access{}
+		// If JSON decode fails, try a base64 encoded JSON string (both options are around for backwards compatibility)
+		jsonErr := json.Unmarshal([]byte(accessStr), &access)
+		if jsonErr != nil {
+			decodedData, decodeErr := base64.RawURLEncoding.DecodeString(accessStr)
+			if decodeErr != nil {
+				return nil, errF(knox.BadRequestDataCode, decodeErr.Error())
+			}
+			jsonErr := json.Unmarshal(decodedData, &access)
+			if jsonErr != nil {
+				return nil, errF(knox.BadRequestDataCode, jsonErr.Error())
+			}
+		}
+		acl = append(acl, access)
+	} else if aclOK {
+		decodedData, decodeErr := base64.RawURLEncoding.DecodeString(aclStr)
 		if decodeErr != nil {
 			return nil, errF(knox.BadRequestDataCode, decodeErr.Error())
 		}
-		jsonErr := json.Unmarshal(decodedData, &access)
+		jsonErr := json.Unmarshal(decodedData, &acl)
 		if jsonErr != nil {
 			return nil, errF(knox.BadRequestDataCode, jsonErr.Error())
 		}
+	} else {
+		return nil, errF(knox.BadRequestDataCode, "Missing acl and access parameters")
 	}
 
 	// Get the Key
@@ -302,19 +318,21 @@ func putAccessHandler(m KeyManager, principal knox.Principal, parameters map[str
 		return nil, errF(knox.UnauthorizedCode, "")
 	}
 
-	// If access type change is not "None" (i.e. we're adding, not deleting, an ACL entry) then
-	// we apply validation on the ID string to make sure it conforms to the expectations of the
-	// particular principal type. We do this to block empty machines prefixes and other invalid
-	// or bad entries.
-	if access.AccessType != knox.None {
-		principalErr := access.Type.IsValidPrincipal(access.ID, extraPrincipalValidators)
-		if principalErr != nil {
-			return nil, errF(knox.BadPrincipalIdentifier, principalErr.Error())
+	for _, access := range acl {
+		// If access type change is not "None" (i.e. we're adding, not deleting, an ACL entry) then
+		// we apply validation on the ID string to make sure it conforms to the expectations of the
+		// particular principal type. We do this to block empty machines prefixes and other invalid
+		// or bad entries.
+		if access.AccessType != knox.None {
+			principalErr := access.Type.IsValidPrincipal(access.ID, extraPrincipalValidators)
+			if principalErr != nil {
+				return nil, errF(knox.BadPrincipalIdentifier, principalErr.Error())
+			}
 		}
 	}
 
 	// Update Access
-	updateErr := m.UpdateAccess(keyID, access)
+	updateErr := m.UpdateAccess(keyID, acl...)
 	if updateErr != nil {
 		return nil, errF(knox.InternalServerErrorCode, updateErr.Error())
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -292,11 +292,7 @@ func putAccessHandler(m KeyManager, principal knox.Principal, parameters map[str
 		}
 		acl = append(acl, access)
 	} else if aclOK {
-		decodedData, decodeErr := base64.RawURLEncoding.DecodeString(aclStr)
-		if decodeErr != nil {
-			return nil, errF(knox.BadRequestDataCode, decodeErr.Error())
-		}
-		jsonErr := json.Unmarshal(decodedData, &acl)
+		jsonErr := json.Unmarshal([]byte(aclStr), &acl)
 		if jsonErr != nil {
 			return nil, errF(knox.BadRequestDataCode, jsonErr.Error())
 		}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -320,6 +320,72 @@ func TestGetAccess(t *testing.T) {
 
 func TestPutAccess(t *testing.T) {
 	m, db := makeDB()
+	access := []knox.Access{knox.Access{Type: knox.Machine, ID: "MrRoboto", AccessType: knox.Read}}
+	accessJSON, jerr := json.Marshal(&access)
+	if jerr != nil {
+		t.Fatalf("%+v is not nil", jerr)
+	}
+
+	u := auth.NewUser("testuser", []string{})
+	machine := auth.NewMachine("MrRoboto")
+	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	if err != nil {
+		t.Fatalf("%+v is not nil", err)
+	}
+
+	_, err = putAccessHandler(m, u, map[string]string{"keyID": "a1", "acl": "NotJSON"})
+	if err == nil {
+		t.Fatal("Expected err")
+	}
+	_, err = putAccessHandler(m, u, map[string]string{"keyID": "NOTAKEY", "acl": string(accessJSON)})
+	if err == nil {
+		t.Fatal("Expected err")
+	}
+
+	_, err = putAccessHandler(m, machine, map[string]string{"keyID": "a1", "acl": string(accessJSON)})
+	if err == nil {
+		t.Fatal("Expected err")
+	}
+
+	_, err = putAccessHandler(m, u, map[string]string{"keyID": "a1", "acl": string(accessJSON)})
+	if err != nil {
+		t.Fatalf("%+v is not nil", err)
+	}
+
+	db.SetError(fmt.Errorf("Test Error"))
+	_, err = putAccessHandler(m, u, map[string]string{"keyID": "a1", "acl": string(accessJSON)})
+	if err == nil {
+		t.Fatal("Expected err")
+	}
+
+	db.SetError(nil)
+	_, err = getKeyHandler(m, machine, map[string]string{"keyID": "a1"})
+	if err != nil {
+		t.Fatalf("%+v is not nil", err)
+	}
+
+	//Tests for setting ACLs with empty machinePrefix
+	//Should return error when used with AccessType Read,Write, or Admin
+	//Should return success when used with AccessType None(useful for revoking such existing ACLs)
+	accessTypes := []knox.AccessType{knox.None, knox.Read, knox.Write, knox.Admin}
+	for _, accessType := range accessTypes {
+		access = []knox.Access{knox.Access{Type: knox.MachinePrefix, ID: "", AccessType: accessType}}
+		accessJSON, jerr = json.Marshal(&access)
+		if jerr != nil {
+			t.Fatalf("%+v is not nil", jerr)
+		}
+		_, err = putAccessHandler(m, u, map[string]string{"keyID": "a1", "acl": string(accessJSON)})
+		if err == nil && accessType != knox.None {
+			t.Fatal("Expected err")
+		} else if err != nil && accessType == knox.None {
+			t.Fatalf("%+v is not nil", err)
+		}
+	}
+
+}
+
+func TestLegacyPutAccess(t *testing.T) {
+	m, db := makeDB()
 	access := &knox.Access{Type: knox.Machine, ID: "MrRoboto", AccessType: knox.Read}
 	accessJSON, jerr := json.Marshal(access)
 	if jerr != nil {
@@ -386,7 +452,6 @@ func TestPutAccess(t *testing.T) {
 			t.Fatalf("%+v is not nil", err)
 		}
 	}
-
 }
 
 func TestPostVersion(t *testing.T) {


### PR DESCRIPTION
This will allow for knox key acls to be updated in bulk without running numerous commands. We can also create template acl files to make key generation easier for complex services.