### PR TITLE
Add more verbose error messages

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -274,14 +274,7 @@ func putAccessHandler(m KeyManager, principal knox.Principal, parameters map[str
 	keyID := parameters["keyID"]
 
 	accessStr, accessOK := parameters["access"]
-<<<<<<< HEAD
 	aclStr, aclOK := parameters["acl"]
-=======
-	if !accessOK {
-		return nil, errF(knox.BadRequestDataCode, "Missing parameter 'access'")
-	}
-	access := knox.Access{}
->>>>>>> 8625655... add better error messages
 
 	acl := []knox.Access{}
 	if accessOK {


### PR DESCRIPTION
These messages get passed in the logs and back to the client -- make them verbose enough that people can know more details about the failure.
