### PR TITLE
Log fallback auth types and provider names

### DIFF
--- a/knox.go
+++ b/knox.go
@@ -506,17 +506,22 @@ func (kvl KeyVersionList) Update(versionID uint64, s VersionStatus) (KeyVersionL
 type Principal interface {
 	CanAccess(ACL, AccessType) bool
 	GetID() string
+	Type() string
 }
 
 // PrincipalMux provides a Principal Interface over multiple Principals.
 type PrincipalMux struct {
-	principals []Principal
+	// The default principal to use in the mux.
+	defaultPrincipal Principal
+
+	// All principals being muxed, including the default, indexed by provider.
+	allPrincipals map[string]Principal
 }
 
 // CanAccess will check the principals in order of adding, and the first
 // Principal that provides at least the AccessType requested will be used.
 func (p PrincipalMux) CanAccess(acl ACL, accessType AccessType) bool {
-	for _, p := range p.principals {
+	for _, p := range p.allPrincipals {
 		if p.CanAccess(acl, accessType) {
 			return true
 		}
@@ -526,24 +531,34 @@ func (p PrincipalMux) CanAccess(acl ACL, accessType AccessType) bool {
 
 // GetID returns the first registered ID.
 func (p PrincipalMux) GetID() string {
-	if len(p.principals) == 0 {
-		return "No Principal Found"
+	return p.defaultPrincipal.GetID()
+}
+
+// Type returns the underlying type of a principal, for logging/debugging purposes.
+func (p PrincipalMux) Type() string {
+	if len(p.allPrincipals) == 1 {
+		return p.defaultPrincipal.Type()
 	}
-	return p.principals[0].GetID()
+
+	types := []string{}
+	for provider, principal := range p.allPrincipals {
+		types = append(types, fmt.Sprintf("%s=>%s", provider, principal.Type()))
+	}
+
+	// Outputs a string like 'mux[foo=>user, bar=>service]'.
+	return fmt.Sprintf("mux[%s]", strings.Join(types, ","))
 }
 
 // Default returns the first registered Principal.
 func (p PrincipalMux) Default() Principal {
-	if len(p.principals) == 0 {
-		return nil
-	}
-	return p.principals[0]
+	return p.defaultPrincipal
 }
 
 // NewPrincipalMux returns a Principal that represents many principals.
-func NewPrincipalMux(p ...Principal) Principal {
+func NewPrincipalMux(defaultPrincipal Principal, allPrincipals map[string]Principal) Principal {
 	return PrincipalMux{
-		principals: p,
+		defaultPrincipal: defaultPrincipal,
+		allPrincipals:    allPrincipals,
 	}
 }
 

--- a/knox.go
+++ b/knox.go
@@ -534,6 +534,15 @@ func (p PrincipalMux) GetID() string {
 	return p.defaultPrincipal.GetID()
 }
 
+// GetIDs returns all registered IDs from the principals that are muxed.
+func (p PrincipalMux) GetIDs() []string {
+	ids := []string{}
+	for _, principal := range p.allPrincipals {
+		ids = append(ids, principal.GetID())
+	}
+	return ids
+}
+
 // Type returns the underlying type of a principal, for logging/debugging purposes.
 func (p PrincipalMux) Type() string {
 	if len(p.allPrincipals) == 1 {

--- a/knox.go
+++ b/knox.go
@@ -529,7 +529,7 @@ func (p PrincipalMux) CanAccess(acl ACL, accessType AccessType) bool {
 	return false
 }
 
-// GetID returns the first registered ID.
+// GetID returns the ID of the default principal.
 func (p PrincipalMux) GetID() string {
 	return p.defaultPrincipal.GetID()
 }

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -294,6 +294,11 @@ func (u user) GetID() string {
 	return u.ID
 }
 
+// Type returns the underlying type of a principal, for logging/debugging purposes.
+func (u user) Type() string {
+	return "user"
+}
+
 // CanAccess determines if a User can access an object represented by the ACL
 // with a certain AccessType. It compares LDAP username and LDAP group.
 func (u user) CanAccess(acl knox.ACL, t knox.AccessType) bool {
@@ -317,6 +322,11 @@ type machine string
 
 func (m machine) GetID() string {
 	return string(m)
+}
+
+// Type returns the underlying type of a principal, for logging/debugging purposes.
+func (m machine) Type() string {
+	return "machine"
 }
 
 // CanAccess determines if a Machine can access an object represented by the ACL
@@ -347,6 +357,11 @@ type service struct {
 // GetID converts the internal representation into a SPIFFE id
 func (s service) GetID() string {
 	return "spiffe://" + s.domain + "/" + s.id
+}
+
+// Type returns the underlying type of a principal, for logging/debugging purposes.
+func (s service) Type() string {
+	return "service"
 }
 
 // CanAccess determines if a Service can access an object represented by the ACL

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -15,6 +15,7 @@ import (
 
 // Provider is used for authenticating requests via the authentication decorator.
 type Provider interface {
+	Name() string
 	Authenticate(token string, r *http.Request) (knox.Principal, error)
 	Version() byte
 	Type() byte
@@ -66,6 +67,11 @@ func (p *MTLSAuthProvider) Version() byte {
 	return '0'
 }
 
+// Name is the name of the provider for logging
+func (p *MTLSAuthProvider) Name() string {
+	return "mtls"
+}
+
 // Type is set to t for MTLSAuthProvider
 func (p *MTLSAuthProvider) Type() byte {
 	return 't'
@@ -106,6 +112,11 @@ type SpiffeProvider struct {
 // Version is set to 0 for SpiffeProvider
 func (p *SpiffeProvider) Version() byte {
 	return '0'
+}
+
+// Name is the name of the provider for logging
+func (p *SpiffeProvider) Name() string {
+	return "spiffe"
 }
 
 // Type is set to s for SpiffeProvider
@@ -158,6 +169,11 @@ func NewSpiffeAuthFallbackProvider(CAs *x509.CertPool) *SpiffeFallbackProvider {
 	}
 }
 
+// Name is the name of the provider for logging
+func (p *SpiffeFallbackProvider) Name() string {
+	return "spiffe-fallback"
+}
+
 // Type is set to be identical to the Type of the MTLSAuthProvider
 func (s *SpiffeFallbackProvider) Type() byte {
 	return (&MTLSAuthProvider{}).Type()
@@ -176,6 +192,11 @@ func NewGitHubProvider(httpTimeout time.Duration) *GitHubProvider {
 // Version is set to 0 for GitHubProvider
 func (p *GitHubProvider) Version() byte {
 	return '0'
+}
+
+// Name is the name of the provider for logging
+func (p *GitHubProvider) Name() string {
+	return "github"
 }
 
 // Type is set to u for GitHubProvider since it authenticates users

--- a/server/decorators.go
+++ b/server/decorators.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
 
 	"github.com/gorilla/context"
 	"github.com/pinterest/knox"
@@ -212,8 +211,7 @@ func Authentication(providers []auth.Provider) func(http.HandlerFunc) http.Handl
 
 					// We record the name of the provider to be used in logging, so we can record
 					// information about which provider authenticated which principal later on.
-					providerName := reflect.TypeOf(p).String()
-					allPrincipals[providerName] = principal
+					allPrincipals[p.Name()] = principal
 				}
 			}
 			if defaultPrincipal == nil {

--- a/server/decorators.go
+++ b/server/decorators.go
@@ -212,7 +212,7 @@ func Authentication(providers []auth.Provider) func(http.HandlerFunc) http.Handl
 
 					// We record the name of the provider to be used in logging, so we can record
 					// information about which provider authenticated which principal later on.
-					providerName := reflect.TypeOf(p).Name()
+					providerName := reflect.TypeOf(p).String()
 					allPrincipals[providerName] = principal
 				}
 			}

--- a/server/decorators.go
+++ b/server/decorators.go
@@ -128,19 +128,20 @@ type reqLog struct {
 }
 
 type request struct {
-	Method      string            `json:"method"`
-	Path        string            `json:"path"`
-	Parameters  map[string]string `json:"parameters"`
-	ParsedQuery map[string]string `json:"parsed_query_string"`
-	Principal   string            `json:"principal"`
-	AuthType    string            `json:"auth_type"`
-	RequestURI  string            `json:"request_uri"`
-	RemoteAddr  string            `json:"remote_addr"`
-	TLSServer   string            `json:"tls_server"`
-	TLSCipher   uint16            `json:"tls_cipher"`
-	TLSVersion  uint16            `json:"tls_version"`
-	TLSResumed  bool              `json:"tls_resumed"`
-	TLSUnique   []byte            `json:"tls_session_id"`
+	Method             string            `json:"method"`
+	Path               string            `json:"path"`
+	Parameters         map[string]string `json:"parameters"`
+	ParsedQuery        map[string]string `json:"parsed_query_string"`
+	Principal          string            `json:"principal"`
+	FallbackPrincipals []string          `json:"fallback_principals"`
+	AuthType           string            `json:"auth_type"`
+	RequestURI         string            `json:"request_uri"`
+	RemoteAddr         string            `json:"remote_addr"`
+	TLSServer          string            `json:"tls_server"`
+	TLSCipher          uint16            `json:"tls_cipher"`
+	TLSVersion         uint16            `json:"tls_version"`
+	TLSResumed         bool              `json:"tls_resumed"`
+	TLSUnique          []byte            `json:"tls_session_id"`
 }
 
 func scrub(params map[string]string) map[string]string {
@@ -175,6 +176,9 @@ func buildRequest(req *http.Request, p knox.Principal, params map[string]string)
 	if p != nil {
 		r.Principal = p.GetID()
 		r.AuthType = p.Type()
+		if mux, ok := p.(knox.PrincipalMux); ok {
+			r.FallbackPrincipals = mux.GetIDs()
+		}
 	} else {
 		r.Principal = ""
 		r.AuthType = ""


### PR DESCRIPTION
Instead of just logging the first auth type from a principal mux if multiple principals are available we now log all of them. This gives us better debuggability in cases where we're deadling with multiple auth providers, logs will now output all matching principals along with the name of the providers that authenticated them.

With this change, the logs will now show an `auth_type` along the lines of `mux[foo=>user, bar=>service]` on requests where multiple auth providers matched. This might be the case if, for example, a client certificate had a valid hostname as well as a SPIFFE ID for auth. 