### PR TITLE
Better SPIFFE ID parsing, error checking

### DIFF
--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -346,6 +346,25 @@ func TestSpiffeSuccess(t *testing.T) {
 	testSpiffeAuthFlow(t, "0sANYTHING", &a)
 }
 
+func TestSpiffeToPrincipalBadInput(t *testing.T) {
+	inputs := [][]string{
+		nil,
+		{},
+		{""},
+		{"!"},
+		{"foo"},
+		{"spiffe:/asdf"},
+		{"a", "b"},
+	}
+
+	for _, input := range inputs {
+		_, err := spiffeToPrincipal(input)
+		if err == nil {
+			t.Errorf("Input %s should return err, but did not", input)
+		}
+	}
+}
+
 func testSpiffeAuthFlow(t *testing.T, authHeader string, provider Provider) {
 	expected := "spiffe://example.com/service"
 	req, err := http.NewRequest("GET", "http://localhost/", nil)
@@ -369,7 +388,7 @@ func testSpiffeAuthFlow(t *testing.T, authHeader string, provider Provider) {
 		t.Fatal("Authenticated principal is not a service")
 	}
 	if p.GetID() != expected {
-		t.Fatal("Service ID differs from expected result")
+		t.Fatalf("Service ID differs from expected result (result was %s)", p.GetID())
 	}
 }
 


### PR DESCRIPTION
Better SPIFFE ID parsing, error checking on certs with invalid SPIFFEs. Especially important now that we have fallback.

Test output (for new test) before code changes:
```
❯❯❯ go test . -run=TestSpiffeToPrincipalBadInput
--- FAIL: TestSpiffeToPrincipalBadInput (0.00s)
panic: runtime error: slice bounds out of range [9:0] [recovered]
	panic: runtime error: slice bounds out of range [9:0]

goroutine 19 [running]:
testing.tRunner.func1.1(0x1257120, 0xc00013e1a0)
	/usr/local/Cellar/go/1.15.5/libexec/src/testing/testing.go:1072 +0x30d
testing.tRunner.func1(0xc00010e300)
	/usr/local/Cellar/go/1.15.5/libexec/src/testing/testing.go:1075 +0x41a
panic(0x1257120, 0xc00013e1a0)
	/usr/local/Cellar/go/1.15.5/libexec/src/runtime/panic.go:969 +0x1b9
github.com/pinterest/knox/server/auth.spiffeToPrincipal(0xc000101040, 0x1, 0x1, 0xc000038770, 0x10edc51, 0x106ef62, 0x105746c)
	/Users/cstaub/Development/knox/server/auth/auth.go:147 +0x1eb
github.com/pinterest/knox/server/auth.TestSpiffeToPrincipalBadInput(0xc00010e300)
	/Users/cstaub/Development/knox/server/auth/auth_test.go:359 +0x205
testing.tRunner(0xc00010e300, 0x1285380)
	/usr/local/Cellar/go/1.15.5/libexec/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
	/usr/local/Cellar/go/1.15.5/libexec/src/testing/testing.go:1168 +0x2b3
FAIL	github.com/pinterest/knox/server/auth	0.168s
FAIL
```

After code changes:
```
~/D/k/s/auth ❯❯❯ go test . -run=TestSpiffeToPrincipalBadInput
ok  	github.com/pinterest/knox/server/auth	0.229s
```