### PR TITLE
Fix go vet warning in go1.16.3

### DIFF
--- a/server/http_test.go
+++ b/server/http_test.go
@@ -253,10 +253,10 @@ func TestConcurrentAddKeys(t *testing.T) {
 		getKeys(t)
 		key := getKey(t, "testkey")
 		if key.VersionList[0].ID != keyID {
-			t.Fatal("Key ID's do not match")
+			t.Error("Key ID's do not match")
 		}
 		if !bytes.Equal(key.VersionList[0].Data, data) {
-			t.Fatal("Data is not consistant")
+			t.Error("Data is not consistant")
 		}
 	}()
 	wg.Add(1)

--- a/server/keydb/keydb_test.go
+++ b/server/keydb/keydb_test.go
@@ -140,31 +140,31 @@ func TesterErrs(t *testing.T, db DB, expErr error) {
 	go func() {
 		_, err := db.GetAll()
 		if err != expErr {
-			t.Fatalf("%s does not equal %s", err, expErr)
+			t.Errorf("%s does not equal %s", err, expErr)
 		}
 	}()
 	go func() {
 		err := db.Add(&k)
 		if err != expErr {
-			t.Fatalf("%s does not equal %s", err, expErr)
+			t.Errorf("%s does not equal %s", err, expErr)
 		}
 	}()
 	go func() {
 		err := db.Remove(k.ID)
 		if err != expErr {
-			t.Fatalf("%s does not equal %s", err, expErr)
+			t.Errorf("%s does not equal %s", err, expErr)
 		}
 	}()
 	go func() {
 		err := db.Update(&k)
 		if err != expErr {
-			t.Fatalf("%s does not equal %s", err, expErr)
+			t.Errorf("%s does not equal %s", err, expErr)
 		}
 	}()
 	go func() {
 		_, err := db.Get(k.ID)
 		if err != expErr {
-			t.Fatalf("%s does not equal %s", err, expErr)
+			t.Errorf("%s does not equal %s", err, expErr)
 		}
 	}()
 }


### PR DESCRIPTION
We were triggering fatal failures from within a go routine which does not work. I switched the fatal calls to be errors.