### PR TITLE
Add functionality to specify token file location in Initialization function

### DIFF
--- a/client/command.go
+++ b/client/command.go
@@ -45,6 +45,8 @@ import (
 	"github.com/pinterest/knox"
 )
 
+const defaultTokenFileLocation = ".knox_user_auth"
+
 var cli knox.APIClient
 
 // VisibilityParams exposes functions for the knox client to provide information
@@ -59,9 +61,10 @@ var errorf = func(string, ...interface{}) {}
 var daemonReportMetrics = func(map[string]uint64) {}
 var knoxAuthClientID = ""
 var knoxOAuthTokenEndpoint = ""
+var knoxTokenFileLocation = ""
 
 // Run is how to execute commands. It uses global variables and isn't safe to call in parallel.
-func Run(client knox.APIClient, p *VisibilityParams, tokenEndpoint, clientID string) {
+func Run(client knox.APIClient, p *VisibilityParams, tokenEndpoint, clientID string, homeRelativeTokenFileLocation string) {
 	cli = client
 	if p != nil {
 		if p.Logf != nil {
@@ -76,6 +79,11 @@ func Run(client knox.APIClient, p *VisibilityParams, tokenEndpoint, clientID str
 	}
 	knoxAuthClientID = clientID
 	knoxOAuthTokenEndpoint = tokenEndpoint
+	knoxTokenFileLocation = homeRelativeTokenFileLocation
+
+	if homeRelativeTokenFileLocation == "" {
+		knoxTokenFileLocation = defaultTokenFileLocation
+	}
 
 	flag.Usage = usage
 	flag.Parse()

--- a/client/login.go
+++ b/client/login.go
@@ -21,7 +21,7 @@ var cmdLogin = &Command{
 	UsageLine: "login [username]",
 	Short:     "login as user and save authentication data",
 	Long: `
-Will authenticate user via OAuth2 password grant flow if available. Requires user to enter username and password. The authentication data is saved in "~/.knox_user_auth".
+Will authenticate user via OAuth2 password grant flow if available. Requires user to enter username and password. By default, the authentication data is saved in "~/.knox_user_auth".
 
 The optional username argument can specify the user that to log in as otherwise it uses the current os user.
 
@@ -79,7 +79,7 @@ func runLogin(cmd *Command, args []string) {
 	if authResp.Error != "" {
 		fatalf("Fail to authenticate: %q", authResp.Error)
 	}
-	authFile := path.Join(u.HomeDir, "/.knox_user_auth")
+	authFile := path.Join(u.HomeDir, knoxTokenFileLocation)
 	err = ioutil.WriteFile(authFile, data, 0600)
 	if err != nil {
 		fatalf("Failed to write auth data to file" + err.Error())

--- a/cmd/dev_client/main.go
+++ b/cmd/dev_client/main.go
@@ -120,8 +120,12 @@ func main() {
 		AuthHandler: authHandler,
 		KeyFolder:   keyFolder,
 		Client:      &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}},
-		Version:     client.GetVersion(),
 	}
 
-	client.Run(cli, &client.VisibilityParams{Logf: log.Printf, Errorf: log.Printf, Metrics: func(map[string]uint64) {}}, tokenEndpoint, clientID)
+	client.Run(
+		cli,
+		&client.VisibilityParams{log.Printf, log.Printf, func(map[string]uint64) {}},
+		tokenEndpoint,
+		clientID,
+		"")
 }

--- a/cmd/dev_client/main.go
+++ b/cmd/dev_client/main.go
@@ -124,7 +124,10 @@ func main() {
 
 	client.Run(
 		cli,
-		&client.VisibilityParams{log.Printf, log.Printf, func(map[string]uint64) {}},
+		&client.VisibilityParams{
+			Logf:    log.Printf,
+			Errorf:  log.Printf,
+			Metrics: func(map[string]uint64) {}},
 		tokenEndpoint,
 		clientID,
 		"")


### PR DESCRIPTION
- Make it possible to allow a caller to set a custom location for the Knox Auth File (it will still default to `knox_user_auth`)
- Unfortunately, the help text cannot easily be updated due to how the object graph is initialized. I have added a clarification to the text file but we will need a broader refactor for how commands are initialized before we can have command text be a function of client variables