### PR TITLE
Add New Feature: Create A New Tink Keyset With A Supported Tink Key Template

### DIFF
--- a/client/create.go
+++ b/client/create.go
@@ -8,12 +8,22 @@ import (
 	"github.com/pinterest/knox"
 )
 
+func init() {
+	cmdCreate.Run = runCreate // break init cycle
+}
+
 var cmdCreate = &Command{
-	Run:       runCreate,
-	UsageLine: "create <key_identifier>",
+	UsageLine: "create [--key-template template_name] <key_identifier>",
 	Short:     "creates a new key",
 	Long: `
-Create will create a new key in knox with original data set as the primary data. Key data should be sent to stdin.
+Create will create a new key in knox with original data set as the primary data. There are two ways to provide data in order to create a new key.
+
+First way: key data is sent to stdin.
+Please use command "create <key_identifier>". 
+
+Second way: using supported tink key template to create a new tink keyset containing a single key, which will be used as the data directly.
+Please use command "create --key-template template_name <key_identifier>".
+To check supported tink key templates, please use command "key-templates".
 
 The original key version id will be print to stdout.
 
@@ -24,16 +34,25 @@ For more about knox, see https://github.com/pinterest/knox.
 See also: knox add, knox get
 	`,
 }
+var createTinkKeyset = cmdCreate.Flag.Bool("key-template", false, "")
 
 func runCreate(cmd *Command, args []string) {
-	if len(args) != 1 {
-		fatalf("create takes exactly one argument. See 'knox help create'")
+	if len(args) != 1 && len(args) != 2 || len(args) == 2 && !*createTinkKeyset ||
+		len(args) != 2 && *createTinkKeyset {
+		fatalf("unsupported command. See 'knox help create'")
 	}
-	fmt.Println("Reading from stdin...")
-	keyID := args[0]
-	data, err := ioutil.ReadAll(os.Stdin)
-	if err != nil {
-		fatalf("Problem reading key data: %s", err.Error())
+	var keyID string
+	var data []byte
+	if *createTinkKeyset {
+		templateName := args[0]
+		keyID = args[1]
+		if err := checkTemplateNameAndKnoxIDForTinkKeyset(templateName, keyID); err != nil {
+			fatalf(err.Error())
+		}
+		data = createNewTinkKeyset(tinkKeyTemplates[templateName].templateFunc)
+	} else {
+		keyID = args[0]
+		data = readDataFromStdin()
 	}
 	// TODO(devinlundberg): allow ACL to be entered as input
 	acl := knox.ACL{}
@@ -42,4 +61,13 @@ func runCreate(cmd *Command, args []string) {
 		fatalf("Error adding version: %s", err.Error())
 	}
 	fmt.Printf("Created key with initial version %d\n", versionID)
+}
+
+func readDataFromStdin() []byte {
+	fmt.Println("Reading from stdin...")
+	data, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		fatalf("Problem reading key data: %s", err.Error())
+	}
+	return data
 }

--- a/client/tink_keyset_helper.go
+++ b/client/tink_keyset_helper.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -49,11 +50,12 @@ func nameOfSupportedTinkKeyTemplates() string {
 
 // checkTemplateNameAndKnoxIDForTinkKeyset checks whether knox identifier start with "tink:<tink_primitive_short_name>:".
 func checkTemplateNameAndKnoxIDForTinkKeyset(templateName string, knoxIentifier string) error {
-	templateInfo, existed := tinkKeyTemplates[templateName]
-	if !existed {
-		return errors.New("not supported keyset template. See 'knox key-templates'")
+	templateInfo, ok := tinkKeyTemplates[templateName]
+	if !ok {
+		return errors.New("not supported Tink key template. See 'knox key-templates'")
 	} else if !strings.HasPrefix(knoxIentifier, templateInfo.knoxIDPrefix) {
-		return errors.New("<key_identifier> must have prefix '" + templateInfo.knoxIDPrefix + "'")
+		errInfo := fmt.Sprintf("<key_identifier> must have prefix '%s'", templateInfo.knoxIDPrefix)
+		return errors.New(errInfo)
 	}
 	return nil
 }
@@ -73,7 +75,8 @@ func convertTinkKeysetHandleToBytes(keysetHandle *keyset.Handle) []byte {
 	bytesBuffer := new(bytes.Buffer)
 	writer := keyset.NewBinaryWriter(bytesBuffer)
 	// To write cleartext keyset handle, must use package "insecurecleartextkeyset"
-	if err := insecurecleartextkeyset.Write(keysetHandle, writer); err != nil {
+	err := insecurecleartextkeyset.Write(keysetHandle, writer)
+	if err != nil {
 		fatalf("cannot write tink keyset: %v", err)
 	}
 	return bytesBuffer.Bytes()

--- a/client/tink_keyset_helper.go
+++ b/client/tink_keyset_helper.go
@@ -1,12 +1,16 @@
 package client
 
 import (
+	"bytes"
+	"errors"
 	"sort"
 	"strings"
 
 	"github.com/google/tink/go/aead"
 	"github.com/google/tink/go/daead"
 	"github.com/google/tink/go/hybrid"
+	"github.com/google/tink/go/insecurecleartextkeyset"
+	"github.com/google/tink/go/keyset"
 	"github.com/google/tink/go/mac"
 	"github.com/google/tink/go/signature"
 	"github.com/google/tink/go/streamingaead"
@@ -41,4 +45,36 @@ func nameOfSupportedTinkKeyTemplates() string {
 	}
 	sort.Strings(supportedTemplates)
 	return strings.Join(supportedTemplates, "\n")
+}
+
+// checkTemplateNameAndKnoxIDForTinkKeyset checks whether knox identifier start with "tink:<tink_primitive_short_name>:".
+func checkTemplateNameAndKnoxIDForTinkKeyset(templateName string, knoxIentifier string) error {
+	templateInfo, existed := tinkKeyTemplates[templateName]
+	if !existed {
+		return errors.New("not supported keyset template. See 'knox key-templates'")
+	} else if !strings.HasPrefix(knoxIentifier, templateInfo.knoxIDPrefix) {
+		return errors.New("<key_identifier> must have prefix '" + templateInfo.knoxIDPrefix + "'")
+	}
+	return nil
+}
+
+// createNewTinkKeyset creates a new tink keyset contains a single fresh key from the given tink key templateFunc.
+func createNewTinkKeyset(templateFunc func() *tinkpb.KeyTemplate) []byte {
+	// Creates a keyset handle that contains a single fresh key
+	keysetHandle, err := keyset.NewHandle(templateFunc())
+	if keysetHandle == nil || err != nil {
+		fatalf("cannot get tink keyset handle: %v", err)
+	}
+	return convertTinkKeysetHandleToBytes(keysetHandle)
+}
+
+// convertTinkKeysetHandleToBytes extracts keyset from tink keyset handle and converts it to bytes
+func convertTinkKeysetHandleToBytes(keysetHandle *keyset.Handle) []byte {
+	bytesBuffer := new(bytes.Buffer)
+	writer := keyset.NewBinaryWriter(bytesBuffer)
+	// To write cleartext keyset handle, must use package "insecurecleartextkeyset"
+	if err := insecurecleartextkeyset.Write(keysetHandle, writer); err != nil {
+		fatalf("cannot write tink keyset: %v", err)
+	}
+	return bytesBuffer.Bytes()
 }

--- a/client/tink_keyset_helper_test.go
+++ b/client/tink_keyset_helper_test.go
@@ -1,8 +1,13 @@
 package client
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/mac"
+	"github.com/google/tink/go/testkeyset"
 )
 
 func TestNameOfSupportedTinkKeyTemplates(t *testing.T) {
@@ -20,5 +25,66 @@ func TestNameOfSupportedTinkKeyTemplates(t *testing.T) {
 	expected := strings.Join(names, "\n")
 	if expected != nameOfSupportedTinkKeyTemplates() {
 		t.Fatalf("cannot list name of supported tink key templates correctly")
+	}
+}
+
+func TestCheckTemplateNameAndKnoxIDForTinkKeyset(t *testing.T) {
+	if err := checkTemplateNameAndKnoxIDForTinkKeyset("invalid", "invalid"); err == nil {
+		t.Fatalf("cannot check whether knox identifier for tink keyset obey the naming rule")
+	}
+	if err := checkTemplateNameAndKnoxIDForTinkKeyset("TINK_AEAD_AES256_GCM", "invalid"); err == nil {
+		t.Fatalf("cannot check whether knox identifier for tink keyset obey the naming rule")
+	}
+	if err := checkTemplateNameAndKnoxIDForTinkKeyset("TINK_AEAD_AES256_GCM", "tink:dsig:"); err == nil {
+		t.Fatalf("cannot check whether knox identifier for tink keyset obey the naming rule")
+	}
+	if err := checkTemplateNameAndKnoxIDForTinkKeyset("TINK_AEAD_AES256_GCM", "tink:aead:"); err != nil {
+		t.Fatalf("cannot check whether knox identifier for tink keyset obey the naming rule")
+	}
+}
+
+func TestCreateNewTinkKeyset(t *testing.T) {
+	keyTemplate := mac.HMACSHA512Tag256KeyTemplate
+	keysetInBytes := createNewTinkKeyset(keyTemplate)
+	bytesBuffer := new(bytes.Buffer)
+	bytesBuffer.Write(keysetInBytes)
+	tinkKeyset, err := keyset.NewBinaryReader(bytesBuffer).Read()
+	if err != nil {
+		t.Fatalf("unexpected error reading tink keyset data: %v", err)
+	}
+	if len(tinkKeyset.Key) != 1 {
+		t.Fatalf("incorrect number of keys in the keyset: %d", len(tinkKeyset.Key))
+	}
+	tinkKey := tinkKeyset.Key[0]
+	if tinkKeyset.PrimaryKeyId != tinkKey.KeyId {
+		t.Fatalf("incorrect primary key id, expect %d, got %d", tinkKey.KeyId, tinkKeyset.PrimaryKeyId)
+	}
+	if tinkKey.KeyData.TypeUrl != keyTemplate().TypeUrl {
+		t.Fatalf("incorrect type url, expect %s, got %s", keyTemplate().TypeUrl, tinkKey.KeyData.TypeUrl)
+	}
+	keysetHandle, err := testkeyset.NewHandle(tinkKeyset)
+	if err != nil {
+		t.Fatalf("unexpected error creating new KeysetHandle: %v", err)
+	}
+	if _, err = mac.New(keysetHandle); err != nil {
+		t.Fatalf("cannot get primitive from generated keyset: %s", err)
+	}
+}
+
+func TestConvertTinkKeysetHandleToBytes(t *testing.T) {
+	keyTemplate := mac.HMACSHA256Tag128KeyTemplate()
+	keysetHandle, err := keyset.NewHandle(keyTemplate)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	keysetInBytes := convertTinkKeysetHandleToBytes(keysetHandle)
+	bytesBuffer := new(bytes.Buffer)
+	bytesBuffer.Write(keysetInBytes)
+	tinkKeyset, err := keyset.NewBinaryReader(bytesBuffer).Read()
+	if err != nil {
+		t.Fatalf("unexpected error reading tink keyset data: %v", err)
+	}
+	if err := keyset.Validate(tinkKeyset); err != nil {
+		t.Fatalf("cannot extract keyset from keyset handle and convert it to bytes")
 	}
 }


### PR DESCRIPTION
Modify the create command. Add a new option: create a new Tink keyset that contains a single fresh Tink key with a supported Tink key template. This Tink keyset will be stored on Knox directly.