### PR TITLE
Add New Feature: Add A New Tink Keyset With A Supported Tink Key Template

### DIFF
--- a/client/add.go
+++ b/client/add.go
@@ -42,17 +42,17 @@ func runAdd(cmd *Command, args []string) {
 	var err error
 	if *addTinkKeyset != "" {
 		templateName := *addTinkKeyset
-		err = checkTemplateNameAndKnoxIDForTinkKeyset(templateName, keyID)
+		err = obeyNamingRule(templateName, keyID)
 		if err != nil {
 			fatalf(err.Error())
 		}
 		// get all versions (primary, active, inactive) of this knox identifier
-		var allExistedVersions *knox.Key
-		allExistedVersions, err = cli.NetworkGetKeyWithStatus(keyID, knox.Inactive)
+		var allVersions *knox.Key
+		allVersions, err = cli.NetworkGetKeyWithStatus(keyID, knox.Inactive)
 		if err != nil {
 			fatalf("Error getting key: %s", err.Error())
 		}
-		data, err = addNewTinkKeyset(tinkKeyTemplates[templateName].templateFunc, allExistedVersions.VersionList)
+		data, err = addNewTinkKeyset(tinkKeyTemplates[templateName].templateFunc, allVersions.VersionList)
 	} else {
 		data, err = readDataFromStdin()
 	}

--- a/client/add.go
+++ b/client/add.go
@@ -2,16 +2,25 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
+
+	"github.com/pinterest/knox"
 )
 
+func init() {
+	cmdAdd.Run = runAdd // break init cycle
+}
+
 var cmdAdd = &Command{
-	Run:       runAdd,
-	UsageLine: "add <key_identifier>",
+	UsageLine: "add [--key-template template_name] <key_identifier>",
 	Short:     "adds a new key version to knox",
 	Long: `
-add adds a new key version to an existing key in knox. Key data should be sent to stdin.
+Add will add a new key version to an existing key in knox. Key data of new version should be sent to stdin unless a key-template is specified.
+
+First way: key data of new version is sent to stdin.
+Please run "knox add <key_identifier>". 
+
+Second way: the key-template option can be used to specify a template to generate the new key version, instead of stdin. For available key templates, run "knox key-templates".
+Please run "knox add --key-template template_name <key_identifier>".
 
 This key version will be set to active upon creation. The version id will be sent to stdout on creation.
 
@@ -22,16 +31,33 @@ For more about knox, see https://github.com/pinterest/knox.
 See also: knox create, knox promote
 	`,
 }
+var addTinkKeyset = cmdAdd.Flag.String("key-template", "", "")
 
 func runAdd(cmd *Command, args []string) {
 	if len(args) != 1 {
 		fatalf("add takes only one argument. See 'knox help add'")
 	}
-	fmt.Println("Reading from stdin...")
 	keyID := args[0]
-	data, err := ioutil.ReadAll(os.Stdin)
+	var data []byte
+	var err error
+	if *addTinkKeyset != "" {
+		templateName := *addTinkKeyset
+		err = checkTemplateNameAndKnoxIDForTinkKeyset(templateName, keyID)
+		if err != nil {
+			fatalf(err.Error())
+		}
+		// get all versions (primary, active, inactive) of this knox identifier
+		var allExistedVersions *knox.Key
+		allExistedVersions, err = cli.NetworkGetKeyWithStatus(keyID, knox.Inactive)
+		if err != nil {
+			fatalf("Error getting key: %s", err.Error())
+		}
+		data, err = addNewTinkKeyset(tinkKeyTemplates[templateName].templateFunc, allExistedVersions.VersionList)
+	} else {
+		data, err = readDataFromStdin()
+	}
 	if err != nil {
-		fatalf("Problem reading key data: %s", err.Error())
+		fatalf(err.Error())
 	}
 	versionID, err := cli.AddVersion(keyID, data)
 	if err != nil {

--- a/client/create.go
+++ b/client/create.go
@@ -44,7 +44,7 @@ func runCreate(cmd *Command, args []string) {
 	var err error
 	if *createTinkKeyset != "" {
 		templateName := *createTinkKeyset
-		err = checkTemplateNameAndKnoxIDForTinkKeyset(templateName, keyID)
+		err = obeyNamingRule(templateName, keyID)
 		if err != nil {
 			fatalf(err.Error())
 		}

--- a/client/create.go
+++ b/client/create.go
@@ -22,7 +22,7 @@ First way: key data is sent to stdin.
 Please run "knox create <key_identifier>". 
 
 Second way: the key-template option can be used to specify a template to generate the initial primary key version, instead of stdin. For available key templates, run "knox key-templates".
-Please run "knox create --key-template template_name <key_identifier>".
+Please run "knox create --key-template <template_name> <key_identifier>".
 
 The original key version id will be print to stdout.
 
@@ -33,7 +33,7 @@ For more about knox, see https://github.com/pinterest/knox.
 See also: knox add, knox get
 	`,
 }
-var createTinkKeyset = cmdCreate.Flag.String("key-template", "", "")
+var createTinkKeyset = cmdCreate.Flag.String("key-template", "", "name of a knox-supported Tink key template")
 
 func runCreate(cmd *Command, args []string) {
 	if len(args) != 1 {

--- a/client/tink_keyset_helper_test.go
+++ b/client/tink_keyset_helper_test.go
@@ -110,7 +110,7 @@ func TestConvertTinkKeysetHandleToBytes(t *testing.T) {
 // key. Argument counts decides how many versions are in this dummy veriosn list. Argument templateFunc decides
 // the type of created Tink keyset in each version.
 func getDummyKnoxVersionList(
-	counts int, 
+	counts int,
 	templateFunc func() *tinkpb.KeyTemplate,
 ) (knox.KeyVersionList, map[uint32]uint64) {
 	var dummyVersionList knox.KeyVersionList
@@ -119,12 +119,12 @@ func getDummyKnoxVersionList(
 	for i := 0; i < counts; i++ {
 		// get a tink keyset in bytes that contains a fresh single key and the keyID is not duplicated
 		var keysetInbytes []byte
-		for{
+		for {
 			keysetHandle, err := keyset.NewHandle(templateFunc())
 			if keysetHandle == nil || err != nil {
 				fatalf("cannot get tink keyset handle: %v", err)
 			}
-			_, ok := tinkKeyIDToKnoxVersionID[keysetHandle.KeysetInfo().PrimaryKeyId];
+			_, ok := tinkKeyIDToKnoxVersionID[keysetHandle.KeysetInfo().PrimaryKeyId]
 			if !ok {
 				// This is a not duplicated Tink Key ID, use it to add a new Knox version
 				// To be noticed, index i is used as the dummy knox version ID
@@ -148,9 +148,9 @@ func getDummyKnoxVersionList(
 		}
 		// To be noticed, index i is used as dummy knox version ID and dummy creation time.
 		dummyVersionList = append(dummyVersionList, knox.KeyVersion{
-			ID: uint64(i),
-			Data: keysetInbytes,
-			Status: status,
+			ID:           uint64(i),
+			Data:         keysetInbytes,
+			Status:       status,
 			CreationTime: int64(i),
 		})
 	}
@@ -177,7 +177,7 @@ func TestAddNewTinkKeyset(t *testing.T) {
 		t.Fatalf("incorrect number of keys in the keyset: %d", len(tinkKeyset.Key))
 	}
 	tinkKey := tinkKeyset.Key[0]
-	_, ok := tinkKeyIDToKnoxVersionID[tinkKey.KeyId]; 
+	_, ok := tinkKeyIDToKnoxVersionID[tinkKey.KeyId]
 	if ok {
 		t.Fatalf("the ID of new Tink key is duplicated")
 	}

--- a/client/tink_keyset_helper_test.go
+++ b/client/tink_keyset_helper_test.go
@@ -33,20 +33,20 @@ func TestNameOfSupportedTinkKeyTemplates(t *testing.T) {
 	}
 }
 
-func TestCheckTemplateNameAndKnoxIDForTinkKeyset(t *testing.T) {
-	if err := checkTemplateNameAndKnoxIDForTinkKeyset("invalid", "invalid"); err == nil {
+func TestObeyNamingRule(t *testing.T) {
+	if err := obeyNamingRule("invalid", "invalid"); err == nil {
 		t.Fatalf("cannot identify invalid tink key template")
 	}
 	for k := range tinkKeyTemplates {
 		illegalKnoxIdentifier := "wrongKnoxIdentifier"
-		err := checkTemplateNameAndKnoxIDForTinkKeyset(k, illegalKnoxIdentifier)
+		err := obeyNamingRule(k, illegalKnoxIdentifier)
 		if err == nil {
 			t.Fatalf("cannot identify illegal knox identifer for template '%s'", k)
 		}
 	}
 	for k, v := range tinkKeyTemplates {
 		legalKnoxIdentifier := v.knoxIDPrefix + "test"
-		err := checkTemplateNameAndKnoxIDForTinkKeyset(k, legalKnoxIdentifier)
+		err := obeyNamingRule(k, legalKnoxIdentifier)
 		if err != nil {
 			t.Fatalf("cannot accept legal knox identifer for template '%s'", k)
 		}

--- a/client/tink_keyset_helper_test.go
+++ b/client/tink_keyset_helper_test.go
@@ -5,9 +5,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/insecurecleartextkeyset"
 	"github.com/google/tink/go/keyset"
 	"github.com/google/tink/go/mac"
 	"github.com/google/tink/go/testkeyset"
+	"github.com/pinterest/knox"
+
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
 )
 
 func TestNameOfSupportedTinkKeyTemplates(t *testing.T) {
@@ -97,5 +102,118 @@ func TestConvertTinkKeysetHandleToBytes(t *testing.T) {
 	}
 	if err := keyset.Validate(tinkKeyset); err != nil {
 		t.Fatalf("when convert tink keyset handle to bytes, the keyset becomes invalid")
+	}
+}
+
+// getDummyKnoxVersionList is a helper for test. It returns a dummy knox version list for testing and a map from
+// Tink key ID to knox version ID. The data of each version is a Tink keyset in bytes that contains a single Tink
+// key. Argument counts decides how many versions are in this dummy veriosn list. Argument templateFunc decides
+// the type of created Tink keyset in each version.
+func getDummyKnoxVersionList(
+	counts int, 
+	templateFunc func() *tinkpb.KeyTemplate,
+) (knox.KeyVersionList, map[uint32]uint64) {
+	var dummyVersionList knox.KeyVersionList
+	tinkKeyIDToKnoxVersionID := make(map[uint32]uint64)
+	// counts decide how many versions this dummy version list will have
+	for i := 0; i < counts; i++ {
+		// get a tink keyset in bytes that contains a fresh single key and the keyID is not duplicated
+		var keysetInbytes []byte
+		for{
+			keysetHandle, err := keyset.NewHandle(templateFunc())
+			if keysetHandle == nil || err != nil {
+				fatalf("cannot get tink keyset handle: %v", err)
+			}
+			_, ok := tinkKeyIDToKnoxVersionID[keysetHandle.KeysetInfo().PrimaryKeyId];
+			if !ok {
+				// This is a not duplicated Tink Key ID, use it to add a new Knox version
+				// To be noticed, index i is used as the dummy knox version ID
+				tinkKeyIDToKnoxVersionID[keysetHandle.KeysetInfo().PrimaryKeyId] = uint64(i)
+				bytesBuffer := new(bytes.Buffer)
+				writer := keyset.NewBinaryWriter(bytesBuffer)
+				err := insecurecleartextkeyset.Write(keysetHandle, writer)
+				if err != nil {
+					fatalf("cannot write tink keyset: %v", err)
+				}
+				keysetInbytes = bytesBuffer.Bytes()
+				break
+			}
+		}
+		// Add a new version to the dummy version list. Only one Primary version, all others are Active version.
+		var status knox.VersionStatus
+		if i == 0 {
+			status = knox.Primary
+		} else {
+			status = knox.Active
+		}
+		// To be noticed, index i is used as dummy knox version ID and dummy creation time.
+		dummyVersionList = append(dummyVersionList, knox.KeyVersion{
+			ID: uint64(i),
+			Data: keysetInbytes,
+			Status: status,
+			CreationTime: int64(i),
+		})
+	}
+	return dummyVersionList, tinkKeyIDToKnoxVersionID
+}
+
+func TestAddNewTinkKeyset(t *testing.T) {
+	keyTemplate := aead.AES256GCMKeyTemplate
+	// create a dummy version list has one hunderd thousand Tink keys, this large number of Tink keys
+	// is used to check whether func addNewTinkKeyset will add duplicated Key
+	dummyVersionList, tinkKeyIDToKnoxVersionID := getDummyKnoxVersionList(100000, keyTemplate)
+	newKeysetInBytes, err := addNewTinkKeyset(keyTemplate, dummyVersionList)
+	if err != nil {
+		t.Fatalf("cannot add new Tink keyset: %v", err)
+	}
+	// convert bytes to a Tink keyset, and check whether it is a valid keyset
+	bytesBuffer := new(bytes.Buffer)
+	bytesBuffer.Write(newKeysetInBytes)
+	tinkKeyset, err := keyset.NewBinaryReader(bytesBuffer).Read()
+	if err != nil {
+		t.Fatalf("unexpected error reading tink keyset data: %v", err)
+	}
+	if len(tinkKeyset.Key) != 1 {
+		t.Fatalf("incorrect number of keys in the keyset: %d", len(tinkKeyset.Key))
+	}
+	tinkKey := tinkKeyset.Key[0]
+	_, ok := tinkKeyIDToKnoxVersionID[tinkKey.KeyId]; 
+	if ok {
+		t.Fatalf("the ID of new Tink key is duplicated")
+	}
+	if tinkKeyset.PrimaryKeyId != tinkKey.KeyId {
+		t.Fatalf("incorrect primary key id, expect %d, got %d", tinkKey.KeyId, tinkKeyset.PrimaryKeyId)
+	}
+	if tinkKey.KeyData.TypeUrl != keyTemplate().TypeUrl {
+		t.Fatalf("incorrect type url, expect %s, got %s", keyTemplate().TypeUrl, tinkKey.KeyData.TypeUrl)
+	}
+	keysetHandle, err := testkeyset.NewHandle(tinkKeyset)
+	if err != nil {
+		t.Fatalf("unexpected error creating new KeysetHandle: %v", err)
+	}
+	if _, err = aead.New(keysetHandle); err != nil {
+		t.Fatalf("cannot get primitive from generated keyset: %s", err)
+	}
+}
+
+func TestReadTinkKeysetFromBytes(t *testing.T) {
+	keyTemplate := mac.HMACSHA256Tag128KeyTemplate()
+	keysetHandle, err := keyset.NewHandle(keyTemplate)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	bytesBuffer := new(bytes.Buffer)
+	writer := keyset.NewBinaryWriter(bytesBuffer)
+	err = insecurecleartextkeyset.Write(keysetHandle, writer)
+	if err != nil {
+		t.Fatalf("unexpected error writing tink keyset handle")
+	}
+	tinkKeyset, err := readTinkKeysetFromBytes(bytesBuffer.Bytes())
+	if err != nil {
+		t.Fatalf("cannot read tink keyset from bytes")
+	}
+	err = keyset.Validate(tinkKeyset)
+	if err != nil {
+		t.Fatalf("the result of readTinkKeysetFromBytes is not a valid Tink keyset")
 	}
 }


### PR DESCRIPTION
Modify the add command. Add a new option: add a new Tink keyset that contains a single fresh Tink key with a supported Tink key template to an existed Knox identifier.