### PR TITLE
Handle unregister with a clearer return message

### DIFF
--- a/client/register.go
+++ b/client/register.go
@@ -102,5 +102,5 @@ func runRegister(cmd *Command, args []string) {
 		fmt.Printf("%s", string(data))
 		return
 	}
-	logf("Successfully %ved keys %v", cmdName, ks)
+	logf("Successfully %ved keys %v. Keys are updated by the daemon process every %.0f minutes. Check the log for the most recent run.", cmdName, ks, daemonRefreshTime.Minutes())
 }

--- a/client/register.go
+++ b/client/register.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 	"time"
 )
 
@@ -43,7 +44,7 @@ var registerTimeout = cmdRegister.Flag.Int("t", 5, "")
 const registerRecheckTime = 10 * time.Millisecond
 
 func runRegister(cmd *Command, args []string) {
-	k := NewKeysFile(daemonFolder + daemonToRegister)
+	k := NewKeysFile(path.Join(daemonFolder, daemonToRegister))
 	if *registerRemove && *registerKey == "" && *registerKeyFile == "" {
 		// Short circuit & handle `knox register -r`, which is expected to remove all keys
 		err := k.Lock()

--- a/client/register.go
+++ b/client/register.go
@@ -49,6 +49,7 @@ func runRegister(cmd *Command, args []string) {
 	k := NewKeysFile(daemonFolder + daemonToRegister)
 
 	var err error
+	var cmdName string
 	var ks []string
 	if *registerKey == "" {
 		f := NewKeysFile(*registerKeyFile)
@@ -65,14 +66,16 @@ func runRegister(cmd *Command, args []string) {
 		fatalf("There was an error obtaining file lock: %s", err.Error())
 	}
 	if *registerRemove {
+		cmdName = "unregister"
 		err = k.Overwrite(ks)
 	} else {
+		cmdName = "register"
 		err = k.Add(ks)
 	}
 
 	if err != nil {
 		k.Unlock()
-		fatalf("There was an error registering keys %v: %s", ks, err.Error())
+		fatalf("There was an error %ving keys %v: %s", cmdName, ks, err.Error())
 	}
 	err = k.Unlock()
 	if err != nil {
@@ -98,7 +101,6 @@ func runRegister(cmd *Command, args []string) {
 		}
 		fmt.Printf("%s", string(data))
 		return
-	} else {
-		logf("Successfully registered keys %v", ks)
 	}
+	logf("Successfully %ved keys %v", cmdName, ks)
 }

--- a/client/register.go
+++ b/client/register.go
@@ -16,7 +16,7 @@ var cmdRegister = &Command{
 	Long: `
 Register will cache the key in the file system and keep it up to date using the file system.
 
--r removes all existing registered keys.
+-r removes all existing registered keys. -k or -f will instead replace all registered keys with those specified
 -k specifies a specific key identifier to register
 -f specifies a file containing a new line separated list of key identifiers
 -t specifies a timeout for getting the key from the daemon in seconds


### PR DESCRIPTION
Setup:

The help `knox help register` says:

`-r removes all existing registered keys
`
Expected:

I expected to run `knox register -r` and have it say something like "unregistered all keys" or "these keys were unregistered: [ ... ]"

 

Actual:

1. First, it says "You must include a key or key file to register."

no, i'm trying to unregister them all...

2. So I give it a key: `knox register -r -k foo` I'm not sure if the key needs to be real or not

Then it says "successfully registered foo"

But it actually got rid of everything, as i expected!


Thanks @ryan953  for the report

