### PR TITLE
Fix resource leaking issue in knox client and server auth

### DIFF
--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -247,12 +247,18 @@ func (p *GitHubProvider) getAPI(url, token string, v interface{}) error {
 	if err != nil {
 		return err
 	}
+	fmt.Println("Test status0:", resp.StatusCode, resp.Body == nil)
 	defer resp.Body.Close()
+	fmt.Println("Test status1:", resp.StatusCode, resp.Body == nil)
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("API request returned status: %s", resp.Status)
 	}
+	fmt.Println("Test status2:", resp.StatusCode, resp.Body == nil)
 	decoder := json.NewDecoder(resp.Body)
-	return decoder.Decode(v)
+	fmt.Println("Test status3:", resp.StatusCode, resp.Body == nil)
+	err = decoder.Decode(v)
+	fmt.Println("Test status4:", resp.StatusCode, resp.Body == nil)
+	return err
 }
 
 // GitHubLoginFormat specifies the json return format for /user field.
@@ -427,6 +433,7 @@ func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	a := req.Header.Get("Authorization")
 	if a == "" || a == "Bearer notvalid" {
 		resp.StatusCode = 400
+		resp.Body = ioutil.NopCloser(bytes.NewBuffer(nil))
 		resp.Status = "400 Unauthorized"
 
 		return resp, nil
@@ -444,6 +451,7 @@ func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		return resp, nil
 	default:
 		resp.StatusCode = 404
+		resp.Body = ioutil.NopCloser(bytes.NewBuffer(nil))
 		resp.Status = "404 Not found"
 		return resp, nil
 	}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -247,11 +247,11 @@ func (p *GitHubProvider) getAPI(url, token string, v interface{}) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("API request returned status: %s", resp.Status)
 	}
 	decoder := json.NewDecoder(resp.Body)
-	defer resp.Body.Close()
 	return decoder.Decode(v)
 }
 

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -247,17 +247,12 @@ func (p *GitHubProvider) getAPI(url, token string, v interface{}) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("Test status0:", resp.StatusCode, resp.Body == nil)
 	defer resp.Body.Close()
-	fmt.Println("Test status1:", resp.StatusCode, resp.Body == nil)
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("API request returned status: %s", resp.Status)
 	}
-	fmt.Println("Test status2:", resp.StatusCode, resp.Body == nil)
 	decoder := json.NewDecoder(resp.Body)
-	fmt.Println("Test status3:", resp.StatusCode, resp.Body == nil)
 	err = decoder.Decode(v)
-	fmt.Println("Test status4:", resp.StatusCode, resp.Body == nil)
 	return err
 }
 


### PR DESCRIPTION
Summary: Properly close the resp body for http requests