### PR TITLE
Add checks for empty data or nil data when creating keys or key versions

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -152,6 +152,9 @@ func postKeysHandler(m KeyManager, principal knox.Principal, parameters map[stri
 	if !dataOK {
 		return nil, errF(knox.NoKeyDataCode, "Missing parameter 'data'")
 	}
+	if data == "" {
+		return nil, errF(knox.NoKeyDataCode, "Parameter 'data' is empty")
+	}
 	aclStr, aclOK := parameters["acl"]
 
 	acl := make(knox.ACL, 0)
@@ -347,9 +350,15 @@ func postVersionHandler(m KeyManager, principal knox.Principal, parameters map[s
 	if !dataOK {
 		return nil, errF(knox.BadRequestDataCode, "Missing parameter 'data'")
 	}
+	if dataStr == "" {
+		return nil, errF(knox.BadRequestDataCode, "Parameter 'data' is empty")
+	}
 	decodedData, decodeErr := base64.StdEncoding.DecodeString(dataStr)
 	if decodeErr != nil {
 		return nil, errF(knox.BadRequestDataCode, decodeErr.Error())
+	}
+	if decodedData == nil {
+		return nil, errF(knox.BadRequestDataCode, "Parameter 'data' decoded to nil")
 	}
 
 	// Get the key

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -129,6 +129,11 @@ func TestPostKeys(t *testing.T) {
 		t.Fatal("Expected err")
 	}
 
+	_, err = postKeysHandler(m, u, map[string]string{"id": "a1", "data": ""})
+	if err == nil {
+		t.Fatal("Expected err")
+	}
+
 	j, err := postKeysHandler(m, u, map[string]string{"id": "a2", "data": "MQ==", "acl": "[]"})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
@@ -469,6 +474,11 @@ func TestPostVersion(t *testing.T) {
 	}
 
 	_, err = postVersionHandler(m, u, map[string]string{"keyID": "a1", "data": "NOTBASE64"})
+	if err == nil {
+		t.Fatal("Expected err")
+	}
+
+	_, err = postVersionHandler(m, u, map[string]string{"keyID": "a1", "data": ""})
 	if err == nil {
 		t.Fatal("Expected err")
 	}


### PR DESCRIPTION
This adds some simple checks for empty data sent when creating a key to avoid keys that have no contents or nil contents.