### PR TITLE
Conditional keyOnly response

### DIFF
--- a/server/decorators.go
+++ b/server/decorators.go
@@ -90,6 +90,24 @@ func AddHeader(k, v string) func(http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// AddKeyOnly adds keyOnly parameter based on parsing userAgent
+func AddKeyOnly(addKeyOnlyCondition func(string) bool) func(http.HandlerFunc) http.HandlerFunc {
+	return func(f http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			agent := r.Header.Get("User-Agent")
+
+			if addKeyOnlyCondition(agent) {
+				currParams := GetParams(r)
+				currParams["keyOnly"] = ""
+				setParams(r, currParams)
+				fmt.Println(GetParams(r))
+			}
+
+			f(w, r)
+		}
+	}
+}
+
 // Logger logs the request and response information in json format to the logger given.
 func Logger(logger *log.Logger) func(http.HandlerFunc) http.HandlerFunc {
 	return func(f http.HandlerFunc) http.HandlerFunc {

--- a/server/decorators.go
+++ b/server/decorators.go
@@ -100,7 +100,6 @@ func AddKeyOnly(addKeyOnlyCondition func(string) bool) func(http.HandlerFunc) ht
 				currParams := GetParams(r)
 				currParams["keyOnly"] = ""
 				setParams(r, currParams)
-				fmt.Println(GetParams(r))
 			}
 
 			f(w, r)

--- a/server/routes.go
+++ b/server/routes.go
@@ -41,6 +41,7 @@ var routes = [...]Route{
 		Parameters: []Parameter{
 			UrlParameter("keyID"),
 			QueryParameter("status"),
+			QueryParameter("keyOnly"),
 		},
 	},
 	{
@@ -217,6 +218,13 @@ func getKeyHandler(m KeyManager, principal knox.Principal, parameters map[string
 	}
 	// Zero ACL for key response, in order to avoid caching unnecessarily
 	key.ACL = knox.ACL{}
+
+	// If the keyOnly parameter is set then
+	_, keyOnlyOK := parameters["keyOnly"]
+	if keyOnlyOK {
+		return &key, nil
+	}
+
 	keyAccess := knox.KeyAccess{Key: key, Principal: accessPrincipal}
 	return &keyAccess, nil
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -222,7 +222,7 @@ func getKeyHandler(m KeyManager, principal knox.Principal, parameters map[string
 	// If the keyOnly parameter is set then
 	_, keyOnlyOK := parameters["keyOnly"]
 	if keyOnlyOK {
-		return &key, nil
+		return key, nil
 	}
 
 	keyAccess := knox.KeyAccess{Key: key, Principal: accessPrincipal}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -227,6 +227,25 @@ func TestGetKey(t *testing.T) {
 		}
 	}
 
+	i, err = getKeyHandler(m, u, map[string]string{"keyID": "a1", "keyOnly": ""})
+	switch k := i.(type) {
+	default:
+		t.Fatal("Unexpected type of response")
+	case *knox.Key:
+		if k.ID != "a1" {
+			t.Fatalf("Expected ID to be a1 not %s", k.ID)
+		}
+		if len(k.ACL) != 0 {
+			t.Fatalf("Expected key acl to be empty")
+		}
+		if len(k.VersionList) != 1 {
+			t.Fatalf("Expected len to be 1 not %d", len(k.VersionList))
+		}
+		if string(k.VersionList[0].Data) != "1" {
+			t.Fatalf("Expected ID to be a1 not %s", string(k.VersionList[0].Data))
+		}
+	}
+
 	i, err = getKeyHandler(m, u, map[string]string{"keyID": "a1", "status": "AJSDFLKJlks"})
 	if err == nil {
 		t.Fatal("Expected err")


### PR DESCRIPTION
If keyOnly parameter is set on getKey route then the route will return the key and not a keyAccess.

This PR also adds an example AddKeyOnly decorator which will conditionally add the keyOnly parameter to routes based on a parsing of the UserAgent string