### PR TITLE
Differentiate between 'dont have access' and 'invalid key content' in knox client

### DIFF
--- a/client.go
+++ b/client.go
@@ -228,6 +228,9 @@ func (c *HTTPClient) CacheGetKey(keyID string) (*Key, error) {
 func (c *HTTPClient) NetworkGetKey(keyID string) (*Key, error) {
 	key := &Key{}
 	err := c.getHTTPData("GET", "/v0/keys/"+keyID+"/", nil, key)
+	if err != nil {
+		return nil, err
+	}
 
 	// do not return the invalid format remote keys
 	if key.ID == "" || key.ACL == nil || key.VersionList == nil || key.VersionHash == "" {


### PR DESCRIPTION
https://github.com/pinterest/knox/pull/84/files

added the line
```
// do not return the invalid format remote keys	
if (
 key.ID == "" || 
 key.ACL == nil || 
 key.VersionList == nil ||    
 key.VersionHash == ""
)
{		
   return nil, fmt.Errorf("invalid key content for the remote key")	
} 
```

if someone doesn't have access to a key, then one or more of the above conditions is also true, so we give a misleading error message.