### PR TITLE
Add support for fractional timeouts

### DIFF
--- a/client/register_test.go
+++ b/client/register_test.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseTimeout(t *testing.T) {
+	testCases := []struct {
+		str string
+		dur time.Duration
+	}{
+		{"5", 5 * time.Second},
+		{"5s", 5 * time.Second},
+		{"0.5s", 500 * time.Millisecond},
+		{"500ms", 500 * time.Millisecond},
+	}
+
+	for _, tc := range testCases {
+		r, err := parseTimeout(tc.str)
+		if err != nil {
+			t.Errorf("error parsing value %s: %s", tc.str, err)
+			continue
+		}
+		if r != tc.dur {
+			t.Errorf("mismatch: %s should parse to %s", tc.str, tc.dur.String())
+		}
+	}
+}


### PR DESCRIPTION
Add support for fractional timeouts in the "knox register" command.

Note that in order to specify a fractional timeout, the unit must also be specified. For example, "5s", "0.5s" and "50ms" are all valid values. If no unit is specified, we fall back to treating the flag as an integer value of seconds to we stay backwards-compatible with the old behavior (e.g. "-t5" for 5s).