### PR TITLE
Add new field to json blob for tink keysets

### DIFF
--- a/client/daemon.go
+++ b/client/daemon.go
@@ -2,8 +2,8 @@ package client
 
 import (
 	"bytes"
-	"encoding/json"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -281,16 +281,16 @@ func (d daemon) processKey(keyID string) error {
 	}
 
 	if strings.HasPrefix(keyID, "tink:") {
-                keysetHandle, _, err := getTinkKeysetHandleFromKnoxVersionList(key.VersionList)
-                if err != nil {
-                        return fmt.Errorf("Error fetching keyset handle for this tink key %s: %s", keyID, err.Error())
-                }
-                tinkKeyset, err := convertTinkKeysetHandleToBytes(keysetHandle)
-                if err != nil {
-                        return fmt.Errorf("Error converting tink keyset handle to bytes %s: %s", keyID, err.Error())
-                }
-                key.TinkKeyset = base64.StdEncoding.EncodeToString(tinkKeyset)
-        }
+		keysetHandle, _, err := getTinkKeysetHandleFromKnoxVersionList(key.VersionList)
+		if err != nil {
+			return fmt.Errorf("Error fetching keyset handle for this tink key %s: %s", keyID, err.Error())
+		}
+		tinkKeyset, err := convertTinkKeysetHandleToBytes(keysetHandle)
+		if err != nil {
+			return fmt.Errorf("Error converting tink keyset handle to bytes %s: %s", keyID, err.Error())
+		}
+		key.TinkKeyset = base64.StdEncoding.EncodeToString(tinkKeyset)
+	}
 
 	b, err := json.Marshal(key)
 	if err != nil {

--- a/client/daemon.go
+++ b/client/daemon.go
@@ -49,6 +49,8 @@ var defaultDirPermission os.FileMode = 0777
 
 var daemonRefreshTime = 10 * time.Minute
 
+const tinkPrefix = "tink:"
+
 func runDaemon(cmd *Command, args []string) *ErrorStatus {
 
 	if os.Getenv("KNOX_MACHINE_AUTH") == "" {
@@ -280,7 +282,7 @@ func (d daemon) processKey(keyID string) error {
 		return fmt.Errorf("invalid key content returned")
 	}
 
-	if strings.HasPrefix(keyID, "tink:") {
+	if strings.HasPrefix(keyID, tinkPrefix) {
 		keysetHandle, _, err := getTinkKeysetHandleFromKnoxVersionList(key.VersionList)
 		if err != nil {
 			return fmt.Errorf("Error fetching keyset handle for this tink key %s: %s", keyID, err.Error())

--- a/client/daemon_test.go
+++ b/client/daemon_test.go
@@ -181,46 +181,46 @@ func TestProcessKey(t *testing.T) {
 }
 
 func TestProcessTinkKey(t *testing.T) {
-        params, dir, d := setUpTest(t)
-        defer TearDownTest(dir)
-        expectedTinkKeysetStr := "EmQKWAowdHlwZS5nb29nbGVhcGlzLmNvbS9nb29nbGUuY3J5cHRvLnRpbmsuQWVzR2NtS2V5EiIaIKMfoRISDw+QlZv88fJdP5qQG6sQdX79v6d5rMAi1JFtGAEQARjLvc6/AyAB"
-        var keyVersion knox.KeyVersion
-        keyVersion.ID = 1234567890
-        keyVersion.Data = []byte{8, 203, 189, 206, 191, 3, 18, 100, 10, 88, 10, 48, 116, 121, 112, 101, 46, 103, 111, 111, 103, 108, 101, 97, 112, 105, 115, 46, 99, 111, 109, 47, 103, 111, 111, 103, 108, 101, 46, 99, 114, 121, 112, 116, 111, 46, 116, 105, 110, 107, 46, 65, 101, 115, 71, 99, 109, 75, 101, 121, 18, 34, 26, 32, 163, 31, 161, 18, 18, 15, 15, 144, 149, 155, 252, 241, 242, 93, 63, 154, 144, 27, 171, 16, 117, 126, 253, 191, 167, 121, 172, 192, 34, 212, 145, 109, 24, 1, 16, 1, 24, 203, 189, 206, 191, 3, 32, 1}
-        keyVersion.Status = 1
-        keyVersion.CreationTime = 12345
-        expected := knox.Key{
-                ID:          "tink:aead:my_test_key",
-                ACL:         knox.ACL([]knox.Access{}),
-                VersionList: knox.KeyVersionList{keyVersion},
-                VersionHash: "VersionHash",
-                TinkKeyset: "",
-        }
-        if err := addRegisteredKey(expected.ID, d.registerFilename()); err != nil {
-                t.Fatal("Failed to register key: " + err.Error())
-        }
-        params.setFunc(func(r *http.Request) {
-                switch r.URL.Path {
-                case "/v0/keys/":
-                        setGoodResponse(params, []string{expected.ID})
-                case "/v0/keys/" + expected.ID + "/":
-                        setGoodResponse(params, expected)
-                default:
-                        t.Fatal("Unexpected path:" + r.URL.Path)
-                }
-        })
-        err := d.processKey(expected.ID)
-        if err != nil {
-                t.Fatalf("%s is not nil", err)
-        }
+	params, dir, d := setUpTest(t)
+	defer TearDownTest(dir)
+	expectedTinkKeysetStr := "EmQKWAowdHlwZS5nb29nbGVhcGlzLmNvbS9nb29nbGUuY3J5cHRvLnRpbmsuQWVzR2NtS2V5EiIaIKMfoRISDw+QlZv88fJdP5qQG6sQdX79v6d5rMAi1JFtGAEQARjLvc6/AyAB"
+	var keyVersion knox.KeyVersion
+	keyVersion.ID = 1234567890
+	keyVersion.Data = []byte{8, 203, 189, 206, 191, 3, 18, 100, 10, 88, 10, 48, 116, 121, 112, 101, 46, 103, 111, 111, 103, 108, 101, 97, 112, 105, 115, 46, 99, 111, 109, 47, 103, 111, 111, 103, 108, 101, 46, 99, 114, 121, 112, 116, 111, 46, 116, 105, 110, 107, 46, 65, 101, 115, 71, 99, 109, 75, 101, 121, 18, 34, 26, 32, 163, 31, 161, 18, 18, 15, 15, 144, 149, 155, 252, 241, 242, 93, 63, 154, 144, 27, 171, 16, 117, 126, 253, 191, 167, 121, 172, 192, 34, 212, 145, 109, 24, 1, 16, 1, 24, 203, 189, 206, 191, 3, 32, 1}
+	keyVersion.Status = 1
+	keyVersion.CreationTime = 12345
+	expected := knox.Key{
+		ID:          "tink:aead:my_test_key",
+		ACL:         knox.ACL([]knox.Access{}),
+		VersionList: knox.KeyVersionList{keyVersion},
+		VersionHash: "VersionHash",
+		TinkKeyset:  "",
+	}
+	if err := addRegisteredKey(expected.ID, d.registerFilename()); err != nil {
+		t.Fatal("Failed to register key: " + err.Error())
+	}
+	params.setFunc(func(r *http.Request) {
+		switch r.URL.Path {
+		case "/v0/keys/":
+			setGoodResponse(params, []string{expected.ID})
+		case "/v0/keys/" + expected.ID + "/":
+			setGoodResponse(params, expected)
+		default:
+			t.Fatal("Unexpected path:" + r.URL.Path)
+		}
+	})
+	err := d.processKey(expected.ID)
+	if err != nil {
+		t.Fatalf("%s is not nil", err)
+	}
 
-        cachedTinkKey, err := d.cli.CacheGetKey(expected.ID)
-        if err != nil {
-                t.Fatalf("%s is not nil", err)
-        }
-        if cachedTinkKey.TinkKeyset != expectedTinkKeysetStr {
-                t.Fatalf("%s is not equal to %s", expected.TinkKeyset, expectedTinkKeysetStr)
-        }
+	cachedTinkKey, err := d.cli.CacheGetKey(expected.ID)
+	if err != nil {
+		t.Fatalf("%s is not nil", err)
+	}
+	if cachedTinkKey.TinkKeyset != expectedTinkKeysetStr {
+		t.Fatalf("%s is not equal to %s", expected.TinkKeyset, expectedTinkKeysetStr)
+	}
 }
 
 func TestUpdate(t *testing.T) {

--- a/client/daemon_test.go
+++ b/client/daemon_test.go
@@ -180,6 +180,49 @@ func TestProcessKey(t *testing.T) {
 	}
 }
 
+func TestProcessTinkKey(t *testing.T) {
+        params, dir, d := setUpTest(t)
+        defer TearDownTest(dir)
+        expectedTinkKeysetStr := "EmQKWAowdHlwZS5nb29nbGVhcGlzLmNvbS9nb29nbGUuY3J5cHRvLnRpbmsuQWVzR2NtS2V5EiIaIKMfoRISDw+QlZv88fJdP5qQG6sQdX79v6d5rMAi1JFtGAEQARjLvc6/AyAB"
+        var keyVersion knox.KeyVersion
+        keyVersion.ID = 1234567890
+        keyVersion.Data = []byte{8, 203, 189, 206, 191, 3, 18, 100, 10, 88, 10, 48, 116, 121, 112, 101, 46, 103, 111, 111, 103, 108, 101, 97, 112, 105, 115, 46, 99, 111, 109, 47, 103, 111, 111, 103, 108, 101, 46, 99, 114, 121, 112, 116, 111, 46, 116, 105, 110, 107, 46, 65, 101, 115, 71, 99, 109, 75, 101, 121, 18, 34, 26, 32, 163, 31, 161, 18, 18, 15, 15, 144, 149, 155, 252, 241, 242, 93, 63, 154, 144, 27, 171, 16, 117, 126, 253, 191, 167, 121, 172, 192, 34, 212, 145, 109, 24, 1, 16, 1, 24, 203, 189, 206, 191, 3, 32, 1}
+        keyVersion.Status = 1
+        keyVersion.CreationTime = 12345
+        expected := knox.Key{
+                ID:          "tink:aead:my_test_key",
+                ACL:         knox.ACL([]knox.Access{}),
+                VersionList: knox.KeyVersionList{keyVersion},
+                VersionHash: "VersionHash",
+                TinkKeyset: "",
+        }
+        if err := addRegisteredKey(expected.ID, d.registerFilename()); err != nil {
+                t.Fatal("Failed to register key: " + err.Error())
+        }
+        params.setFunc(func(r *http.Request) {
+                switch r.URL.Path {
+                case "/v0/keys/":
+                        setGoodResponse(params, []string{expected.ID})
+                case "/v0/keys/" + expected.ID + "/":
+                        setGoodResponse(params, expected)
+                default:
+                        t.Fatal("Unexpected path:" + r.URL.Path)
+                }
+        })
+        err := d.processKey(expected.ID)
+        if err != nil {
+                t.Fatalf("%s is not nil", err)
+        }
+
+        cachedTinkKey, err := d.cli.CacheGetKey(expected.ID)
+        if err != nil {
+                t.Fatalf("%s is not nil", err)
+        }
+        if cachedTinkKey.TinkKeyset != expectedTinkKeysetStr {
+                t.Fatalf("%s is not equal to %s", expected.TinkKeyset, expectedTinkKeysetStr)
+        }
+}
+
 func TestUpdate(t *testing.T) {
 	params, dir, d := setUpTest(t)
 	defer TearDownTest(dir)

--- a/knox.go
+++ b/knox.go
@@ -381,7 +381,7 @@ type Key struct {
 	VersionList KeyVersionList `json:"versions"`
 	VersionHash string         `json:"hash"`
 	Path        string         `json:"path,omitempty"`
-	TinkKeyset  string         `json:"tinkKeyset"`
+	TinkKeyset  string         `json:"tinkKeyset,omitempty"`
 }
 
 // Validate calls makes sure all attributes of key are in good state.

--- a/knox.go
+++ b/knox.go
@@ -381,6 +381,7 @@ type Key struct {
 	VersionList KeyVersionList `json:"versions"`
 	VersionHash string         `json:"hash"`
 	Path        string         `json:"path,omitempty"`
+	TinkKeyset  string         `json:"tinkKeyset"`
 }
 
 // Validate calls makes sure all attributes of key are in good state.


### PR DESCRIPTION
This will add a new field to json blob by daemon which will contain primary and all active versions