### PR TITLE
Allow SPIFFEs to create keys

### DIFF
--- a/client/create.go
+++ b/client/create.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,7 +14,7 @@ func init() {
 }
 
 var cmdCreate = &Command{
-	UsageLine: "create [--key-template template_name] <key_identifier>",
+	UsageLine: "create [--acl key_acl] [--key-template template_name] <key_identifier>",
 	Short:     "creates a new key",
 	Long: `
 Create will create a new key in knox with input as the primary key version. Key data should be sent to stdin unless a key-template is specified.
@@ -26,7 +27,8 @@ Please run "knox create --key-template <template_name> <key_identifier>".
 
 The original key version id will be print to stdout.
 
-To create a new key, user credentials are required. The default access list will include the creator of this key and a limited set of site reliablity and security engineers.
+Only users or SPIFFEs can create a new key. For SPIFFEs, an ACL must be provided with at least 1 user or group set as the admin.
+If ACL is not provided, the default access list will include the creator of this key, as well as a limited set of site reliablity and security engineers.
 
 For more about knox, see https://github.com/pinterest/knox.
 
@@ -34,6 +36,34 @@ See also: knox add, knox get
 	`,
 }
 var createTinkKeyset = cmdCreate.Flag.String("key-template", "", "name of a knox-supported Tink key template")
+var createAcl = cmdCreate.Flag.String("acl", "", "ACL for the created key")
+
+func parseAcl(aclString string) (knox.ACL, error) {
+	var err error
+	var accessList []knox.Access
+
+	if aclString == "" {
+		return knox.ACL{}, nil
+	}
+
+	err = json.Unmarshal([]byte(aclString), &accessList)
+	if err != nil {
+		return nil, err
+	}
+
+	acl := knox.ACL(accessList)
+
+	err = acl.Validate()
+	if err != nil {
+		return nil, err
+	}
+	err = acl.ValidateHasHumanAdmin()
+	if err != nil {
+		return nil, err
+	}
+
+	return acl, nil
+}
 
 func runCreate(cmd *Command, args []string) *ErrorStatus {
 	if len(args) != 1 {
@@ -55,8 +85,13 @@ func runCreate(cmd *Command, args []string) *ErrorStatus {
 	if err != nil {
 		return &ErrorStatus{err, false}
 	}
-	// TODO(devinlundberg): allow ACL to be entered as input
-	acl := knox.ACL{}
+
+	var acl knox.ACL
+	acl, err = parseAcl(*createAcl)
+	if err != nil {
+		return &ErrorStatus{fmt.Errorf("Error parsing ACL: %s", err.Error()), false}
+	}
+
 	versionID, err := cli.CreateKey(keyID, data, acl)
 	if err != nil {
 		return &ErrorStatus{fmt.Errorf("Error adding version: %s", err.Error()), true}

--- a/client/create_test.go
+++ b/client/create_test.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pinterest/knox"
+)
+
+func testAclEq(a, b knox.ACL) bool {
+    if len(a) != len(b) {
+        return false
+    }
+    for i := range a {
+        if a[i] != b[i] {
+            return false
+        }
+    }
+    return true
+}
+
+func TestParseAcl(t *testing.T) {
+	machineAdmin := knox.Access{ID: "testmachine1", AccessType: knox.Admin, Type: knox.Machine}
+	userWrite := knox.Access{ID: "testuser", AccessType: knox.Write, Type: knox.User}
+	userAdmin := knox.Access{ID: "testuser", AccessType: knox.Admin, Type: knox.User}
+
+	validAclNoHumanAdmin := knox.ACL([]knox.Access{machineAdmin, userWrite})
+	validAclWithHumanAdmin := knox.ACL([]knox.Access{machineAdmin, userAdmin})
+	blankAcl := knox.ACL{}
+
+	testCases := []struct {
+		str string
+		acl knox.ACL
+		errMsg string
+	}{
+		{
+			`[{"type":"foo","id":"bar","access":"test"}]`,
+			validAclNoHumanAdmin,  // ACL does not matter here
+			"json: Invalid AccessType to convert",
+		},
+	    {
+			`[{"type":"User","id":"testuser","access":"Write"}, {"type":"Machine","id":"testmachine1","access":"Admin"}]`,
+			validAclNoHumanAdmin,
+			"ACL needs to have a user or group set as an admin", // User only has Write access
+	    },
+	    {
+			`[{"type":"Machine","id":"testmachine1","access":"Admin"}, {"type":"User","id":"testuser","access":"Admin"}]`,
+			validAclWithHumanAdmin,
+			"", // Success, no error
+	    },
+	    // Original, and default, behaviour is a blank ACL
+        {
+            ``,
+            blankAcl,
+            "", // Success, no error
+        },
+	}
+
+	for _, tc := range testCases {
+		acl, err := parseAcl(tc.str)
+		if tc.errMsg != "" || err != nil {
+			if err.Error() != tc.errMsg {
+				t.Fatal(err)
+			}
+		} else{
+			if !testAclEq(acl, tc.acl) {
+				t.Fatalf("%v should equal %v", acl, tc.acl)
+			}
+		}
+	}
+}

--- a/client/register_test.go
+++ b/client/register_test.go
@@ -17,12 +17,12 @@ func TestParseTimeout(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		r, err := parseTimeout(tc.str)
+		timeout, err := parseTimeout(tc.str)
 		if err != nil {
 			t.Errorf("error parsing value %s: %s", tc.str, err)
 			continue
 		}
-		if r != tc.dur {
+		if timeout != tc.dur {
 			t.Errorf("mismatch: %s should parse to %s", tc.str, tc.dur.String())
 		}
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -11,6 +11,10 @@ import (
 	"testing"
 )
 
+var DataBytes = []byte("data")
+// I.e. b64encode("data")
+const DataB64Encoded = "ZGF0YQ=="
+
 func TestMockClient(t *testing.T) {
 	p := "primary"
 	a := []string{"active1", "active2"}
@@ -181,8 +185,8 @@ func TestCreateKey(t *testing.T) {
 			t.Fatalf("%s is not %s", r.URL.Path, "/v0/keys/")
 		}
 		r.ParseForm()
-		if r.PostForm["data"][0] != "ZGF0YQ==" {
-			t.Fatalf("%s is not expected: %s", r.PostForm["data"][0], "ZGF0YQ==")
+		if r.PostForm["data"][0] != DataB64Encoded {
+			t.Fatalf("%s is not expected: %s", r.PostForm["data"][0], DataB64Encoded)
 		}
 		if r.PostForm["id"][0] != "testkey" {
 			t.Fatalf("%s is not expected: %s", r.PostForm["id"][0], "testkey")
@@ -195,7 +199,14 @@ func TestCreateKey(t *testing.T) {
 
 	cli := MockClient(srv.Listener.Addr().String(), "")
 
-	acl := ACL([]Access{
+	aclWithUserAdmin := ACL([]Access{
+		{
+			Type:       User,
+			AccessType: Admin,
+			ID:         "test",
+		},
+	})
+	aclWithUserRead := ACL([]Access{
 		{
 			Type:       User,
 			AccessType: Read,
@@ -203,19 +214,40 @@ func TestCreateKey(t *testing.T) {
 		},
 	})
 
-	badACL := ACL([]Access{
+	invalidTypeACL := ACL([]Access{
 		{
-			Type:       233,
-			AccessType: 80927,
+			Type:       233,  // Not a principal
+			AccessType: Read,
 			ID:         "test",
 		},
 	})
-	_, err = cli.CreateKey("testkey", []byte("data"), badACL)
-	if err == nil {
-		t.Fatal("error is nil")
+	_, err = cli.CreateKey("testkey", DataBytes, invalidTypeACL)
+	if err.Error() != "json: error calling MarshalJSON for type knox.PrincipalType: json: Invalid PrincipalType to convert" {
+		t.Fatalf("Expected err is %v", err)
 	}
 
-	k, err := cli.CreateKey("testkey", []byte("data"), acl)
+	invalidAccessTypeACL := ACL([]Access{
+		{
+			Type:       User,
+			AccessType: 80927, // Not an access type
+			ID:         "test",
+		},
+	})
+	_, err = cli.CreateKey("testkey", DataBytes, invalidAccessTypeACL)
+	if err.Error() != "json: error calling MarshalJSON for type knox.AccessType: json: Invalid AccessType to convert" {
+		t.Fatalf("Expected err is %v", err)
+	}
+
+	// Note: In `client/create.go` and `server/routes.go`, acl.ValidateHasHumanAdmin() would be called, but not in `client.go`
+	k, err := cli.CreateKey("testkey", DataBytes, aclWithUserRead)
+	if err != nil {
+		t.Fatalf("%s is not nil", err)
+	}
+	if k != expected {
+		t.Fatalf("%d is not %d", k, expected)
+	}
+
+	k, err = cli.CreateKey("testkey", DataBytes, aclWithUserAdmin)
 	if err != nil {
 		t.Fatalf("%s is not nil", err)
 	}
@@ -238,15 +270,15 @@ func TestAddVersion(t *testing.T) {
 			t.Fatalf("%s is not %s", r.URL.Path, "/v0/keys/testkey/versions/")
 		}
 		r.ParseForm()
-		if r.PostForm["data"][0] != "ZGF0YQ==" {
-			t.Fatalf("%s is not expected: %s", r.PostForm["data"][0], "ZGF0YQ==")
+		if r.PostForm["data"][0] != DataB64Encoded {
+			t.Fatalf("%s is not expected: %s", r.PostForm["data"][0], DataB64Encoded)
 		}
 	})
 	defer srv.Close()
 
 	cli := MockClient(srv.Listener.Addr().String(), "")
 
-	k, err := cli.AddVersion("testkey", []byte("data"))
+	k, err := cli.AddVersion("testkey", DataBytes)
 	if err != nil {
 		t.Fatalf("%s is not nil", err)
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -138,10 +138,29 @@ func getKeysHandler(m KeyManager, principal knox.Principal, parameters map[strin
 // The route for this handler is POST /v0/keys/
 // The postKeysHandler must be a User.
 func postKeysHandler(m KeyManager, principal knox.Principal, parameters map[string]string) (interface{}, *HTTPError) {
+	var err error
+	aclStr, aclOK := parameters["acl"]
 
-	// Authorize
-	if !auth.IsUser(principal) {
-		return nil, errF(knox.UnauthorizedCode, fmt.Sprintf("Must be a user to create keys, principal is %s", principal.GetID()))
+	acl := make(knox.ACL, 0)
+	if aclOK {
+		jsonErr := json.Unmarshal([]byte(aclStr), &acl)
+		if jsonErr != nil {
+			return nil, errF(knox.BadAclCode, jsonErr.Error())
+		}
+	}
+
+	// Only users -- and SPIFFEs when a human group/user is an admin in the ACL -- can create keys
+	if auth.IsService(principal) {
+		err = acl.Validate()
+		if err != nil {
+			return nil, errF(knox.BadAclCode, "Error validating parameter 'acl'")
+		}
+		err = acl.ValidateHasHumanAdmin()
+		if err != nil {
+			return nil, errF(knox.NoHumanAdminInAclCode, "Parameter 'acl' does not have human admin")
+		}
+	} else if !auth.IsUser(principal) {
+		return nil, errF(knox.UnauthorizedCode, fmt.Sprintf("Must be a user (or SPIFFE if human admin in ACL) to create keys, principal is %s", principal.GetID()))
 	}
 
 	keyID, keyIDOK := parameters["id"]
@@ -155,15 +174,6 @@ func postKeysHandler(m KeyManager, principal knox.Principal, parameters map[stri
 	if data == "" {
 		return nil, errF(knox.NoKeyDataCode, "Parameter 'data' is empty")
 	}
-	aclStr, aclOK := parameters["acl"]
-
-	acl := make(knox.ACL, 0)
-	if aclOK {
-		jsonErr := json.Unmarshal([]byte(aclStr), &acl)
-		if jsonErr != nil {
-			return nil, errF(knox.BadRequestDataCode, jsonErr.Error())
-		}
-	}
 
 	decodedData, decodeErr := base64.StdEncoding.DecodeString(data)
 	if decodeErr != nil {
@@ -172,7 +182,7 @@ func postKeysHandler(m KeyManager, principal knox.Principal, parameters map[stri
 
 	// Create and add new key
 	key := newKey(keyID, acl, decodedData, principal)
-	err := m.AddNewKey(&key)
+	err = m.AddNewKey(&key)
 	if err != nil {
 		if err == knox.ErrKeyExists {
 			return nil, errF(knox.KeyIdentifierExistsCode, fmt.Sprintf("Key %s already exists", keyID))

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/pinterest/knox/server/keydb"
 )
 
+const Number1 = "1"
+// I.e. b64encode("1")
+const Number1B64Encoded = "MQ=="
+
 func makeDB() (KeyManager, *keydb.TempDB) {
 	db := &keydb.TempDB{}
 	cryptor := keydb.NewAESGCMCryptor(0, []byte("testtesttesttest"))
@@ -21,7 +25,7 @@ func TestGetKeys(t *testing.T) {
 	m, db := makeDB()
 	u := auth.NewUser("testuser", []string{})
 
-	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": Number1B64Encoded})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}
@@ -86,64 +90,145 @@ func TestGetKeys(t *testing.T) {
 
 func TestPostKeys(t *testing.T) {
 	m, db := makeDB()
+
+	// Machine tests
 	machine := auth.NewMachine("MrRoboto")
-	_, err := postKeysHandler(m, machine, map[string]string{"id": "a1", "data": "MQ=="})
+	// Machines cannot create keys
+	_, err := postKeysHandler(m, machine, map[string]string{"id": "a1", "data": Number1B64Encoded})
 	if err == nil {
 		t.Fatal("Expected err")
+	} else if err.Subcode != knox.UnauthorizedCode {
+		t.Fatalf("Expected %v and got %v", knox.UnauthorizedCode, err.Subcode)
+	} else if err.Message != "Must be a user (or SPIFFE if human admin in ACL) to create keys, principal is MrRoboto" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
 	}
 
-	u := auth.NewUser("testuser", []string{})
-
-	_, err = postKeysHandler(m, u, map[string]string{"data": "MQ=="})
+	// Service tests
+	serviceA := auth.NewService("example.com", "serviceA")
+	// ACL JSON but still Invalid
+	_, err = postKeysHandler(m, serviceA, map[string]string{"id": "a1", "data": Number1B64Encoded, "acl": `[{"type":"foo","id":"bar","access":"test"}]`})
 	if err == nil {
 		t.Fatal("Expected err")
+	} else if err.Subcode != knox.BadAclCode {
+		t.Fatalf("Expected %v and got %v", knox.BadAclCode, err.Subcode)
+	} else if err.Message != "json: Invalid AccessType to convert" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
 	}
-
-	_, err = postKeysHandler(m, u, map[string]string{"id": "a1"})
+	// Valid ACL but no human admin
+	_, err = postKeysHandler(m, serviceA, map[string]string{"id": "a1", "data": Number1B64Encoded, "acl": `[{"type":"User","id":"testuser","access":"Write"}, {"type":"Machine","id":"testmachine1","access":"Admin"}]`})
 	if err == nil {
 		t.Fatal("Expected err")
+	} else if err.Subcode != knox.NoHumanAdminInAclCode {
+		t.Fatalf("Expected %v and got %v", knox.NoHumanAdminInAclCode, err.Subcode)
+	} else if err.Message != "Parameter 'acl' does not have human admin" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
 	}
-
-	_, err = postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ==", "acl": "NOTJSON"})
-	if err == nil {
-		t.Fatal("Expected err")
-	}
-
-	_, err = postKeysHandler(m, u, map[string]string{"id": "a1", "data": "NotBAse64.."})
-	if err == nil {
-		t.Fatal("Expected err")
-	}
-
-	_, err = postKeysHandler(m, u, map[string]string{"id": "a$#", "data": "MQ=="})
-	if err == nil {
-		t.Fatal("Expected err")
-	}
-
-	i, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	// Valid ACL with human admin
+	_, err = postKeysHandler(m, serviceA, map[string]string{"id": "a0", "data": Number1B64Encoded, "acl": `[{"type":"User","id":"testuser","access":"Admin"}, {"type":"Machine","id":"testmachine1","access":"Admin"}]`})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}
 
-	_, err = postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	// User tests
+	testuser := auth.NewUser("testuser", []string{})
+
+	// No id
+	_, err = postKeysHandler(m, testuser, map[string]string{"data": Number1B64Encoded})
 	if err == nil {
 		t.Fatal("Expected err")
+	} else if err.Subcode != knox.NoKeyIDCode {
+		t.Fatalf("Expected %v and got %v", knox.NoKeyIDCode, err.Subcode)
+	} else if err.Message != "Missing parameter 'id'" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
 	}
 
-	_, err = postKeysHandler(m, u, map[string]string{"id": "a1", "data": ""})
+	// No data
+	_, err = postKeysHandler(m, testuser, map[string]string{"id": "a1"})
 	if err == nil {
 		t.Fatal("Expected err")
+	} else if err.Subcode != knox.NoKeyDataCode {
+		t.Fatalf("Expected %v and got %v", knox.NoKeyDataCode, err.Subcode)
+	} else if err.Message != "Missing parameter 'data'" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
 	}
 
-	j, err := postKeysHandler(m, u, map[string]string{"id": "a2", "data": "MQ==", "acl": "[]"})
+	// ACL not JSON
+	_, err = postKeysHandler(m, testuser, map[string]string{"id": "a1", "data": Number1B64Encoded, "acl": "NOTJSON"})
+	if err == nil {
+		t.Fatal("Expected err")
+	} else if err.Subcode != knox.BadAclCode {
+		t.Fatalf("Expected %v and got %v", knox.BadAclCode, err.Subcode)
+	} else if err.Message != "invalid character 'N' looking for beginning of value" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
+	}
+
+	// ACL JSON but still Invalid
+	_, err = postKeysHandler(m, testuser, map[string]string{"id": "a1", "data": Number1B64Encoded, "acl": `[{"type":"foo","id":"bar","access":"test"}]`})
+	if err == nil {
+		t.Fatal("Expected err")
+	} else if err.Subcode != knox.BadAclCode {
+		t.Fatalf("Expected %v and got %v", knox.BadAclCode, err.Subcode)
+	} else if err.Message != "json: Invalid AccessType to convert" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
+	}
+
+	// Base64 decode error on Data
+	_, err = postKeysHandler(m, testuser, map[string]string{"id": "a1", "data": "NotBAse64.."})
+	if err == nil {
+		t.Fatal("Expected err")
+	} else if err.Subcode != knox.BadRequestDataCode {
+		t.Fatalf("Expected %v and got %v", knox.BadRequestDataCode, err.Subcode)
+	} else if err.Message != "illegal base64 data at input byte 9" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
+	}
+
+	// Invalid KeyID
+	_, err = postKeysHandler(m, testuser, map[string]string{"id": "a$#", "data": Number1B64Encoded})
+	if err == nil {
+		t.Fatal("Expected err")
+	} else if err.Subcode != knox.BadKeyFormatCode {
+		t.Fatalf("Expected %v and got %v", knox.BadKeyFormatCode, err.Subcode)
+	} else if err.Message != "KeyID includes unsupported characters a$#" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
+	}
+
+	// Make a1 key
+	a1KeyID, err := postKeysHandler(m, testuser, map[string]string{"id": "a1", "data": Number1B64Encoded})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}
 
-	switch q := i.(type) {
+	// Key already exists
+	_, err = postKeysHandler(m, testuser, map[string]string{"id": "a1", "data": Number1B64Encoded})
+	if err == nil {
+		t.Fatal("Expected err")
+	} else if err.Subcode != knox.KeyIdentifierExistsCode {
+		t.Fatalf("Expected %v and got %v", knox.KeyIdentifierExistsCode, err.Subcode)
+	} else if err.Message != "Key a1 already exists" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
+	}
+
+	// Empty data
+	_, err = postKeysHandler(m, testuser, map[string]string{"id": "a1", "data": ""})
+	if err == nil {
+		t.Fatal("Expected err")
+	} else if err.Subcode != knox.NoKeyDataCode {
+		t.Fatalf("Expected %v and got %v", knox.NoKeyDataCode, err.Subcode)
+	} else if err.Message != "Parameter 'data' is empty" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
+	}
+
+	// Make a2 key
+	a2KeyID, err := postKeysHandler(m, testuser, map[string]string{"id": "a2", "data": Number1B64Encoded, "acl": "[]"})
+	if err != nil {
+		t.Fatalf("%+v is not nil", err)
+	}
+
+	switch q := a1KeyID.(type) {
 	default:
 		t.Fatal("Unexpected type of response")
 	case uint64:
-		switch r := j.(type) {
+		switch r := a2KeyID.(type) {
 		default:
 			t.Fatal("Unexpected type of response")
 		case uint64:
@@ -154,9 +239,13 @@ func TestPostKeys(t *testing.T) {
 	}
 
 	db.SetError(fmt.Errorf("Test Error"))
-	_, err = postKeysHandler(m, u, map[string]string{"id": "a3", "data": "MQ=="})
+	_, err = postKeysHandler(m, testuser, map[string]string{"id": "a3", "data": Number1B64Encoded})
 	if err == nil {
 		t.Fatal("Expected err")
+	} else if err.Subcode != knox.InternalServerErrorCode {
+		t.Fatalf("Expected %v and got %v", knox.InternalServerErrorCode, err.Subcode)
+	} else if err.Message != "Test Error" {
+		t.Fatalf("Unexpected error message: %v", err.Message)
 	}
 }
 
@@ -165,7 +254,7 @@ func TestGetKey(t *testing.T) {
 	machine := auth.NewMachine("MrRoboto")
 
 	u := auth.NewUser("testuser", []string{})
-	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": Number1B64Encoded})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}
@@ -184,7 +273,7 @@ func TestGetKey(t *testing.T) {
 		if len(k.VersionList) != 1 {
 			t.Fatalf("Expected len to be 1 not %d", len(k.VersionList))
 		}
-		if string(k.VersionList[0].Data) != "1" {
+		if string(k.VersionList[0].Data) != Number1 {
 			t.Fatalf("Expected ID to be a1 not %s", string(k.VersionList[0].Data))
 		}
 	}
@@ -203,7 +292,7 @@ func TestGetKey(t *testing.T) {
 		if len(k.VersionList) != 1 {
 			t.Fatalf("Expected len to be 1 not %d", len(k.VersionList))
 		}
-		if string(k.VersionList[0].Data) != "1" {
+		if string(k.VersionList[0].Data) != Number1 {
 			t.Fatalf("Expected ID to be a1 not %s", string(k.VersionList[0].Data))
 		}
 	}
@@ -222,7 +311,7 @@ func TestGetKey(t *testing.T) {
 		if len(k.VersionList) != 1 {
 			t.Fatalf("Expected len to be 1 not %d", len(k.VersionList))
 		}
-		if string(k.VersionList[0].Data) != "1" {
+		if string(k.VersionList[0].Data) != Number1 {
 			t.Fatalf("Expected ID to be a1 not %s", string(k.VersionList[0].Data))
 		}
 	}
@@ -247,7 +336,7 @@ func TestDeleteKey(t *testing.T) {
 	m, db := makeDB()
 	u := auth.NewUser("testuser", []string{})
 	machine := auth.NewMachine("MrRoboto")
-	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": Number1B64Encoded})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}
@@ -289,7 +378,7 @@ func TestGetAccess(t *testing.T) {
 	m, _ := makeDB()
 	u := auth.NewUser("testuser", []string{})
 	machine := auth.NewMachine("MrRoboto")
-	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": Number1B64Encoded})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}
@@ -333,7 +422,7 @@ func TestPutAccess(t *testing.T) {
 
 	u := auth.NewUser("testuser", []string{})
 	machine := auth.NewMachine("MrRoboto")
-	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": Number1B64Encoded})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}
@@ -399,7 +488,7 @@ func TestLegacyPutAccess(t *testing.T) {
 
 	u := auth.NewUser("testuser", []string{})
 	machine := auth.NewMachine("MrRoboto")
-	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	_, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": Number1B64Encoded})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}
@@ -463,7 +552,7 @@ func TestPostVersion(t *testing.T) {
 	m, db := makeDB()
 	u := auth.NewUser("testuser", []string{})
 	machine := auth.NewMachine("MrRoboto")
-	j, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	j, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": Number1B64Encoded})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}
@@ -525,7 +614,7 @@ func TestPutVersions(t *testing.T) {
 	m, db := makeDB()
 	u := auth.NewUser("testuser", []string{})
 	machine := auth.NewMachine("MrRoboto")
-	i, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": "MQ=="})
+	i, err := postKeysHandler(m, u, map[string]string{"id": "a1", "data": Number1B64Encoded})
 	if err != nil {
 		t.Fatalf("%+v is not nil", err)
 	}


### PR DESCRIPTION
Also add the ability to specify ACL on creation, resolving https://github.com/pinterest/knox/blob/ad067734f42798722f803a47fc5a9898011296da/client/create.go#L58
