### PR TITLE
:bug: Fix bug associated with StdErr

### DIFF
--- a/client.go
+++ b/client.go
@@ -135,7 +135,7 @@ func NewMock(primary string, active []string) Client {
 // Register registers the given keyName with knox. If the operation fails, it returns an error.
 func Register(keyID string) ([]byte, error) {
 	cmd := exec.Command("knox", "register", "-g", "-k", keyID)
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("error getting knox key: %s %v '%q'", keyID, err, output)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -509,3 +509,10 @@ func TestGetInvalidKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestNewFileClient(t *testing.T) {
+	_, err := NewFileClient("ThisKeyDoesNotExistSoWeExpectAnError")
+	if (err.Error() != "error getting knox key: ThisKeyDoesNotExistSoWeExpectAnError exit status 1 '\"\"'") && (err.Error() != "error getting knox key: ThisKeyDoesNotExistSoWeExpectAnError exec: \"knox\": executable file not found in $PATH '\"\"'") {
+		t.Fatal("Unexpected error", err.Error())
+	}
+}


### PR DESCRIPTION
CombinedOutput returns standard output and standard error. Because NewFileClient calls Register and then does `json.Unmarshal`, we only want to output stdout.