### PR TITLE
Code change to support public 'SetPrincipal' method

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -105,7 +105,7 @@ func GetRouter(
 
 	m := NewKeyManager(cryptor, db)
 
-	r.NotFoundHandler = setupRoute("404", m)(decorator(writeErr(errF(knox.NotFoundCode, ""))))
+	r.NotFoundHandler = setupRoute("404", m)(decorator(WriteErr(errF(knox.NotFoundCode, ""))))
 
 	for _, route := range allRoutes {
 		addRoute(r, route, decorator, m)
@@ -226,7 +226,9 @@ type Route struct {
 	Parameters []Parameter
 }
 
-func writeErr(apiErr *HTTPError) http.HandlerFunc {
+// WriteErr returns a function that can encode error information and set an
+// HTTP error response code in the specified HTTP response writer
+func WriteErr(apiErr *HTTPError) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		resp := new(knox.Response)
 		hostname, err := os.Hostname()
@@ -249,7 +251,9 @@ func writeErr(apiErr *HTTPError) http.HandlerFunc {
 	}
 }
 
-func writeData(w http.ResponseWriter, data interface{}) {
+// WriteData returns a function that can write arbitrary data to the specified
+// HTTP response writer
+func WriteData(w http.ResponseWriter, data interface{}) {
 	r := new(knox.Response)
 	r.Message = ""
 	r.Code = knox.OKCode
@@ -275,9 +279,9 @@ func (r Route) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	data, err := r.Handler(db, principal, ps)
 
 	if err != nil {
-		writeErr(err)(w, req)
+		WriteErr(err)(w, req)
 	} else {
-		writeData(w, data)
+		WriteData(w, data)
 	}
 }
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -174,7 +174,7 @@ func checkinternalServerErrorResponse(t *testing.T, w *httptest.ResponseRecorder
 
 func TestErrorHandler(t *testing.T) {
 	testErr := errF(knox.InternalServerErrorCode, "")
-	handler := writeErr(testErr)
+	handler := WriteErr(testErr)
 
 	w := httptest.NewRecorder()
 	handler(w, nil)

--- a/server/decorators.go
+++ b/server/decorators.go
@@ -35,14 +35,16 @@ func setAPIError(r *http.Request, val *HTTPError) {
 
 // GetPrincipal gets the principal authenticated through the authentication decorator
 func GetPrincipal(r *http.Request) knox.Principal {
-	if rv := context.Get(r, principalContext); rv != nil {
-		return rv.(knox.Principal)
-	}
-	return nil
+	ctx := getOrInitializePrincipalContext(r)
+	return ctx.GetCurrentPrincipal()
 }
 
-func setPrincipal(r *http.Request, val knox.Principal) {
-	context.Set(r, principalContext, val)
+// SetPrincipal sets the principal authenticated through the authentication decorator.
+// For security reasons, this method will only set the Principal in the context for
+// the first invocation. Subsequent invocations WILL cause a panic.
+func SetPrincipal(r *http.Request, val knox.Principal) {
+	ctx := getOrInitializePrincipalContext(r)
+	ctx.SetCurrentPrincipal(val)
 }
 
 // GetParams gets the parameters for the request through the parameters context.
@@ -66,6 +68,15 @@ func getDB(r *http.Request) KeyManager {
 
 func setDB(r *http.Request, val KeyManager) {
 	context.Set(r, dbContext, val)
+}
+
+func getOrInitializePrincipalContext(r *http.Request) auth.PrincipalContext {
+	if ctx := context.Get(r, principalContext); ctx != nil {
+		return ctx.(auth.PrincipalContext)
+	}
+	ctx := auth.NewPrincipalContext(r)
+	context.Set(r, principalContext, ctx)
+	return ctx
 }
 
 // GetRouteID gets the short form function name for the route being called. Used for logging/metrics.
@@ -223,7 +234,7 @@ func Authentication(providers []auth.Provider) func(http.HandlerFunc) http.Handl
 				return
 			}
 
-			setPrincipal(r, knox.NewPrincipalMux(defaultPrincipal, allPrincipals))
+			SetPrincipal(r, knox.NewPrincipalMux(defaultPrincipal, allPrincipals))
 			f(w, r)
 			return
 		}

--- a/server/decorators.go
+++ b/server/decorators.go
@@ -230,7 +230,7 @@ func Authentication(providers []auth.Provider) func(http.HandlerFunc) http.Handl
 				}
 			}
 			if defaultPrincipal == nil {
-				writeErr(errF(knox.UnauthenticatedCode, errReturned.Error()))(w, r)
+				WriteErr(errF(knox.UnauthenticatedCode, errReturned.Error()))(w, r)
 				return
 			}
 


### PR DESCRIPTION
- In the event that Knox users wish to have a 3rd-party authentication plugin, simplify the code such that users can set a custom principal implementation but still be able to use built-in decorators (e.g. the Logging decorator, which embeds user identity in the logs)