### PR TITLE
Add ACL JSON list output option

### DIFF
--- a/client/getacl.go
+++ b/client/getacl.go
@@ -15,6 +15,8 @@ var cmdGetACL = &Command{
 	Long: `
 Acl get the ACL for a key.
 
+-json: Returns the ACL as a JSON formatted list of access rules, useful for generating files to be used with knox access -acl.
+
 This doesn't require any access to the key and allows, e.g., to see who has admin access to ask for grants.
 
 For more about knox, see https://github.com/pinterest/knox.
@@ -22,6 +24,8 @@ For more about knox, see https://github.com/pinterest/knox.
 See also: knox keys, knox get
 	`,
 }
+
+var getACLJSON = cmdGetACL.Flag.Bool("json", false, "")
 
 func runGetACL(cmd *Command, args []string) *ErrorStatus {
 	if len(args) != 1 {
@@ -32,6 +36,16 @@ func runGetACL(cmd *Command, args []string) *ErrorStatus {
 	acl, err := cli.GetACL(keyID)
 	if err != nil {
 		return &ErrorStatus{fmt.Errorf("Error getting key ACL: %s", err.Error()), true}
+	}
+
+	if *getACLJSON {
+		aclEnc, err := json.Marshal(acl)
+		if err != nil {
+			// malformated ACL considered as knox server side error
+			return &ErrorStatus{fmt.Errorf("Could not marshal ACL: %v", acl), true}
+		}
+		fmt.Println(string(aclEnc))
+		return nil
 	}
 
 	for _, a := range *acl {


### PR DESCRIPTION
 Add a mechanism for writing the ACL out as a JSON list, so it can be fed into knox access -acl

This request came from an internal team.

Tested with a new build locally:
```
❯ bazelisk run .../knox_client -- acl -json jkrach:test:demo_key                                                                                                                                                                                                                                                                                        ...
[{"type":"User","id":"jkrach","access":"Admin"},{"type":"UserGroup","id":"security-team","access":"Admin"},...{"type":"Machine","id":"cli-testing","access":"Read"}]
```