### PR TITLE
Implement Authorization Callback Function

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,12 +1,15 @@
 package knox
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path"
 	"reflect"
+	"runtime"
 	"sync/atomic"
 	"testing"
 )
@@ -75,13 +78,30 @@ func buildServer(code int, body []byte, a func(r *http.Request)) *httptest.Serve
 	}))
 }
 
-func buildConcurrentServer(code int, t *testing.T, a func(r *http.Request) []byte) *httptest.Server {
+func buildConcurrentServer(code int, a func(r *http.Request) []byte) *httptest.Server {
 	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := a(r)
 		w.WriteHeader(code)
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(resp)
 	}))
+}
+
+func isKnoxDaemonRunning() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+
+	cmd := exec.Command("systemctl", "is-active", "--quiet", "knox")
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err == nil {
+		return true
+	}
+
+	return false
 }
 
 func TestGetKey(t *testing.T) {
@@ -357,7 +377,7 @@ func TestPutAccess(t *testing.T) {
 
 func TestConcurrentDeletes(t *testing.T) {
 	var ops uint64
-	srv := buildConcurrentServer(200, t, func(r *http.Request) []byte {
+	srv := buildConcurrentServer(200, func(r *http.Request) []byte {
 		if r.Method != "DELETE" {
 			t.Fatalf("%s is not DELETE", r.Method)
 		}
@@ -511,6 +531,10 @@ func TestGetInvalidKeys(t *testing.T) {
 }
 
 func TestNewFileClient(t *testing.T) {
+	if isKnoxDaemonRunning() {
+		t.Skip("Knox daemon is running, skipping the test.")
+	}
+
 	_, err := NewFileClient("ThisKeyDoesNotExistSoWeExpectAnError")
 	if (err.Error() != "error getting knox key ThisKeyDoesNotExistSoWeExpectAnError. error: exit status 1") && (err.Error() != "error getting knox key ThisKeyDoesNotExistSoWeExpectAnError. error: exec: \"knox\": executable file not found in $PATH") {
 		t.Fatal("Unexpected error", err.Error())

--- a/knox.go
+++ b/knox.go
@@ -508,6 +508,14 @@ type Principal interface {
 	CanAccess(ACL, AccessType) bool
 	GetID() string
 	Type() string
+	Raw() []RawPrincipal
+}
+
+// RawPrincipal is a serializable version of a principal for passing to
+// access callbacks.
+type RawPrincipal struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
 }
 
 // PrincipalMux provides a Principal Interface over multiple Principals.
@@ -564,6 +572,15 @@ func (p PrincipalMux) Default() Principal {
 	return p.defaultPrincipal
 }
 
+// Raw returns the raw version of all the principals.
+func (p PrincipalMux) Raw() []RawPrincipal {
+	raw := []RawPrincipal{}
+	for _, principal := range p.allPrincipals {
+		raw = append(raw, principal.Raw()...)
+	}
+	return raw
+}
+
 // NewPrincipalMux returns a Principal that represents many principals.
 func NewPrincipalMux(defaultPrincipal Principal, allPrincipals map[string]Principal) Principal {
 	return PrincipalMux{
@@ -598,4 +615,11 @@ type Response struct {
 	Timestamp int64       `json:"ts"`
 	Message   string      `json:"message"`
 	Data      interface{} `json:"data"`
+}
+
+// AccessCallbackInput is the input to the access callback function.
+type AccessCallbackInput struct {
+	Key        Key            `json:"key"`
+	Principals []RawPrincipal `json:"principals"`
+	AccessType AccessType     `json:"access_type"`
 }

--- a/server/api.go
+++ b/server/api.go
@@ -294,6 +294,13 @@ func AddDefaultAccess(a *knox.Access) {
 	defaultAccess = append(defaultAccess, *a)
 }
 
+var accessCallback func(knox.AccessCallbackInput) (bool, error)
+
+// SetAccessCallback adds a callback.
+func SetAccessCallback(callback func(knox.AccessCallbackInput) (bool, error)) {
+	accessCallback = callback
+}
+
 // Extra validators to apply on principals submitted to Knox.
 var extraPrincipalValidators []knox.PrincipalValidator
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -110,9 +110,7 @@ func TestAddDefaultAccess(t *testing.T) {
 }
 
 func TestSetAccessCallback(t *testing.T) {
-	defer func() {
-		SetAccessCallback(nil) // Resetting the callback
-	}()
+	defer SetAccessCallback(nil)
 
 	SetAccessCallback(mockAccessCallback)
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -49,6 +49,10 @@ func additionalMockHandler(m KeyManager, principal knox.Principal, parameters ma
 	return "The meaning of life is 42", nil
 }
 
+func mockAccessCallback(input knox.AccessCallbackInput) (bool, error) {
+	return true, nil
+}
+
 func mockRoute() Route {
 	return Route{
 		Method:     "GET",
@@ -103,6 +107,29 @@ func TestAddDefaultAccess(t *testing.T) {
 	}
 	defaultAccess = []knox.Access{}
 
+}
+
+func TestSetAccessCallback(t *testing.T) {
+	defer func() {
+		SetAccessCallback(nil) // Resetting the callback
+	}()
+
+	SetAccessCallback(mockAccessCallback)
+
+	input := knox.AccessCallbackInput{}
+
+	if accessCallback == nil {
+		t.Fatal("accessCallback should not be nil")
+	}
+
+	canAccess, err := accessCallback(input)
+	if err != nil {
+		t.Fatal("accessCallback should not return an error")
+	}
+
+	if !canAccess {
+		t.Fatal("accessCallback should return true")
+	}
 }
 
 func TestParseFormParameter(t *testing.T) {

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -380,6 +380,15 @@ func (u user) GetID() string {
 	return u.ID
 }
 
+func (u user) Raw() []knox.RawPrincipal {
+	return []knox.RawPrincipal{
+		{
+			ID:   u.GetID(),
+			Type: u.Type(),
+		},
+	}
+}
+
 // Type returns the underlying type of a principal, for logging/debugging purposes.
 func (u user) Type() string {
 	return "user"
@@ -415,6 +424,15 @@ func (m machine) Type() string {
 	return "machine"
 }
 
+func (m machine) Raw() []knox.RawPrincipal {
+	return []knox.RawPrincipal{
+		{
+			ID:   m.GetID(),
+			Type: m.Type(),
+		},
+	}
+}
+
 // CanAccess determines if a Machine can access an object represented by the ACL
 // with a certain AccessType. It compares Machine hostname and hostname prefix.
 func (m machine) CanAccess(acl knox.ACL, t knox.AccessType) bool {
@@ -448,6 +466,15 @@ func (s service) GetID() string {
 // Type returns the underlying type of a principal, for logging/debugging purposes.
 func (s service) Type() string {
 	return "service"
+}
+
+func (s service) Raw() []knox.RawPrincipal {
+	return []knox.RawPrincipal{
+		{
+			ID:   s.GetID(),
+			Type: s.Type(),
+		},
+	}
 }
 
 // CanAccess determines if a Service can access an object represented by the ACL

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -608,3 +608,85 @@ func TestPutVersions(t *testing.T) {
 	}
 
 }
+
+func TestAuthorizeRequest(t *testing.T) {
+	u := auth.NewUser("test", []string{"returntrue"})
+	a1 := knox.Access{ID: "test", AccessType: knox.Read, Type: knox.User}
+
+	key := &knox.Key{
+		ID:  "test",
+		ACL: knox.ACL{a1},
+	}
+
+	mockCallbackTrue := func(input knox.AccessCallbackInput) (bool, error) {
+		return true, nil
+	}
+	mockCallbackFalse := func(input knox.AccessCallbackInput) (bool, error) {
+		return false, nil
+	}
+
+	// We will ignore the key's ACL because we are only testing the callback,
+	// which should return true if the AccessType is Write.
+	mockCallbackFalseWithValidInput := func(input knox.AccessCallbackInput) (bool, error) {
+		return input.AccessType == knox.Write && input.Key.ACL[0].ID == "test" && input.Key.ACL[0].Type == knox.User, nil
+	}
+
+	// Mock callback that panics
+	mockCallbackPanic := func(input knox.AccessCallbackInput) (bool, error) {
+		panic("intentional panic")
+	}
+
+	var (
+		authorized bool
+		err        error
+	)
+
+	defer func() {
+		SetAccessCallback(nil) // Resetting the callback
+	}()
+
+	SetAccessCallback(mockCallbackTrue)
+	authorized, err = authorizeRequest(key, u, knox.Write)
+	if err != nil {
+		t.Fatalf("Expected authorizeRequest to return nil error when accessCallback returns true, got %v", err)
+	}
+	if !authorized {
+		t.Fatal("Expected authorizeRequest to return true when accessCallback returns true")
+	}
+
+	SetAccessCallback(mockCallbackFalseWithValidInput)
+	authorized, err = authorizeRequest(key, u, knox.Write)
+	if err != nil {
+		t.Fatalf("Expected authorizeRequest to return nil error when accessCallback returns false with valid input, got %v", err)
+	}
+	if !authorized {
+		t.Fatal("Expected authorizeRequest to return true when accessCallback returns false with valid input")
+	}
+
+	SetAccessCallback(mockCallbackFalse)
+	authorized, err = authorizeRequest(key, u, knox.Write)
+	if err != nil {
+		t.Fatalf("Expected authorizeRequest to return nil error when accessCallback returns false, got %v", err)
+	}
+	if authorized {
+		t.Fatal("Expected authorizeRequest to return false when accessCallback returns false")
+	}
+
+	SetAccessCallback(nil)
+	authorized, err = authorizeRequest(key, u, knox.Write)
+	if err != nil {
+		t.Fatalf("Expected authorizeRequest to return nil error when accessCallback is nil, got %v", err)
+	}
+	if authorized {
+		t.Fatal("Expected authorizeRequest to return false when accessCallback is nil")
+	}
+
+	SetAccessCallback(mockCallbackPanic)
+	authorized, err = authorizeRequest(key, u, knox.Write)
+	if err == nil {
+		t.Fatal("Expected authorizeRequest to return error when accessCallback panics")
+	}
+	if authorized {
+		t.Fatal("Expected authorizeRequest to return false when accessCallback panics")
+	}
+}


### PR DESCRIPTION
### Description

This feature introduces a callback function that allows service owners to define a fallback mechanism for access control within Knox. This capability supports the integration of custom logic to evaluate access decisions.

### Changes Made

- Add new global accessCallback and SetAccessCallback that allows setting a callback function for fallback Access (ex. OPA)
- Add authorizeRequest function to wrap around principal.CanAccess, which additionally will execute the accessCallback when false is returned from principal.CanAccess
- Add a Raw() to all Principal types, which raw version (jsonable ID and Type) of all the principals.
- Modify TestNewFileClient to skip test if running on Linux and have the Knox daemon running

### Testing
Run all tests in the repo, including new ones implemented for SetAccessCallback and authorizeRequest

### Checklist
- [x]  I have run the code locally and it works as expected.
- [x]  I have added tests that prove my fix is effective or that my feature works.
- [x]  I have added necessary documentation (if appropriate).
- [x]  I have reviewed my own code and ensured it follows the code style of this project.