### PR TITLE
feat: allow passing in override http client for auth method

### DIFF
--- a/client.go
+++ b/client.go
@@ -329,10 +329,10 @@ func (c *HTTPClient) UpdateVersion(keyID, versionID string, status VersionStatus
 }
 
 func (c *HTTPClient) getClient() (HTTP, error) {
-	if c.UncachedClient.Client == nil {
-		c.UncachedClient.Client = &http.Client{}
+	if c.UncachedClient.DefaultClient == nil {
+		c.UncachedClient.DefaultClient = &http.Client{}
 	}
-	return c.UncachedClient.Client, nil
+	return c.UncachedClient.DefaultClient, nil
 }
 
 func (c *HTTPClient) getHTTPData(method string, path string, body url.Values, data interface{}) error {
@@ -345,8 +345,8 @@ type UncachedHTTPClient struct {
 	Host string
 	//AuthHandlers contains a list of auth handlers which return the authorization string for authenticating to knox. Users should be prefixed by 0u, machines by 0m. On fail, return empty string.
 	AuthHandlers []AuthHandler
-	// Client is the http client for making network calls
-	Client HTTP
+	// DefaultClient is the http client for making network calls
+	DefaultClient HTTP
 	// Version is the current client version, useful for debugging and sent as a header
 	Version string
 }
@@ -355,10 +355,10 @@ type UncachedHTTPClient struct {
 // NOTE: passing multiple authHandlers can cause severe performance issues, use with caution.
 func NewUncachedClient(host string, client HTTP, authHandlers []AuthHandler, version string) *UncachedHTTPClient {
 	return &UncachedHTTPClient{
-		Host:         host,
-		Client:       client,
-		AuthHandlers: authHandlers,
-		Version:      version,
+		Host:          host,
+		DefaultClient: client,
+		AuthHandlers:  authHandlers,
+		Version:       version,
 	}
 }
 
@@ -487,10 +487,10 @@ func (c *UncachedHTTPClient) UpdateVersion(keyID, versionID string, status Versi
 }
 
 func (c *UncachedHTTPClient) getClient() (HTTP, error) {
-	if c.Client == nil {
-		c.Client = &http.Client{}
+	if c.DefaultClient == nil {
+		c.DefaultClient = &http.Client{}
 	}
-	return c.Client, nil
+	return c.DefaultClient, nil
 }
 
 func (c *UncachedHTTPClient) getHTTPData(method string, path string, body url.Values, data interface{}) error {
@@ -587,8 +587,8 @@ func MockClient(host, keyFolder string) *HTTPClient {
 			AuthHandlers: []AuthHandler{func() (string, HTTP) {
 				return "TESTAUTH", nil
 			}},
-			Client:  &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}},
-			Version: "mock",
+			DefaultClient: &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}},
+			Version:       "mock",
 		},
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -15,6 +15,20 @@ import (
 	"testing"
 )
 
+type mockHTTPClient struct {
+	client  *http.Client
+	counter uint64
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	atomic.AddUint64(&m.counter, 1)
+	return m.client.Do(req)
+}
+
+func (m *mockHTTPClient) getCounter() uint64 {
+	return atomic.LoadUint64(&m.counter)
+}
+
 func TestMockClient(t *testing.T) {
 	p := "primary"
 	a := []string{"active1", "active2"}
@@ -186,14 +200,20 @@ func TestGetKeyWithMultipleAuth(t *testing.T) {
 	})
 	defer srv.Close()
 
-	authHandlerFunc := func() string {
-		return "TESTAUTH"
+	authHandlerFunc := func() (string, HTTP) {
+		return "TESTAUTH", nil
+	}
+	mockClient := &mockHTTPClient{
+		client: &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}},
+	}
+	authHandlerFunc2 := func() (string, HTTP) {
+		return "TESTAUTH2", mockClient
 	}
 	cli := &HTTPClient{
 		KeyFolder: "",
 		UncachedClient: &UncachedHTTPClient{
 			Host:         srv.Listener.Addr().String(),
-			AuthHandlers: []AuthHandler{authHandlerFunc, authHandlerFunc, authHandlerFunc},
+			AuthHandlers: []AuthHandler{authHandlerFunc, authHandlerFunc2, authHandlerFunc2},
 			Client:       &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}},
 			Version:      "mock",
 		},
@@ -224,6 +244,11 @@ func TestGetKeyWithMultipleAuth(t *testing.T) {
 	if ops != 2 {
 		t.Fatalf("%d total client attempts is not 2", ops)
 	}
+
+	// Verify that the mock client was called once
+	if mockClient.getCounter() != 1 {
+		t.Fatalf("%d total mock client attempts is not 1", mockClient.getCounter())
+	}
 }
 
 func TestNoAuth(t *testing.T) {
@@ -239,8 +264,8 @@ func TestNoAuth(t *testing.T) {
 	defer srv.Close()
 
 	// Create an auth handler that returns an empty string (simulating no valid auth)
-	emptyAuthHandler := func() string {
-		return ""
+	emptyAuthHandler := func() (string, HTTP) {
+		return "", nil
 	}
 
 	// Create client with the empty auth handler

--- a/client_test.go
+++ b/client_test.go
@@ -212,10 +212,10 @@ func TestGetKeyWithMultipleAuth(t *testing.T) {
 	cli := &HTTPClient{
 		KeyFolder: "",
 		UncachedClient: &UncachedHTTPClient{
-			Host:         srv.Listener.Addr().String(),
-			AuthHandlers: []AuthHandler{authHandlerFunc, authHandlerFunc2, authHandlerFunc2},
-			Client:       &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}},
-			Version:      "mock",
+			Host:          srv.Listener.Addr().String(),
+			AuthHandlers:  []AuthHandler{authHandlerFunc, authHandlerFunc2, authHandlerFunc2},
+			DefaultClient: &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}},
+			Version:       "mock",
 		},
 	}
 
@@ -272,10 +272,10 @@ func TestNoAuth(t *testing.T) {
 	cli := &HTTPClient{
 		KeyFolder: "",
 		UncachedClient: &UncachedHTTPClient{
-			Host:         srv.Listener.Addr().String(),
-			AuthHandlers: []AuthHandler{emptyAuthHandler},
-			Client:       &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}},
-			Version:      "mock",
+			Host:          srv.Listener.Addr().String(),
+			AuthHandlers:  []AuthHandler{emptyAuthHandler},
+			DefaultClient: &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}},
+			Version:       "mock",
 		},
 	}
 

--- a/cmd/dev_client/main.go
+++ b/cmd/dev_client/main.go
@@ -63,43 +63,43 @@ func getCert() (tls.Certificate, error) {
 
 // authHandler is used to generate an authentication header.
 // The server expects VersionByte + TypeByte + IDToPassToAuthHandler.
-func authHandler() string {
+func authHandler() (string, knox.HTTP) {
 	if s := os.Getenv("KNOX_USER_AUTH"); s != "" {
-		return "0u" + s
+		return "0u" + s, nil
 	}
 	if s := os.Getenv("KNOX_MACHINE_AUTH"); s != "" {
 		c, _ := getCert()
 		x509Cert, err := x509.ParseCertificate(c.Certificate[0])
 		if err != nil {
-			return "0t" + s
+			return "0t" + s, nil
 		}
 		if len(x509Cert.Subject.CommonName) > 0 {
-			return "0t" + x509Cert.Subject.CommonName
+			return "0t" + x509Cert.Subject.CommonName, nil
 		} else if len(x509Cert.DNSNames) > 0 {
-			return "0t" + x509Cert.DNSNames[0]
+			return "0t" + x509Cert.DNSNames[0], nil
 		} else {
-			return "0t" + s
+			return "0t" + s, nil
 		}
 	}
 	if s := os.Getenv("KNOX_SERVICE_AUTH"); s != "" {
-		return "0s" + s
+		return "0s" + s, nil
 	}
 	u, err := user.Current()
 	if err != nil {
-		return ""
+		return "", nil
 	}
 
 	d, err := ioutil.ReadFile(u.HomeDir + "/.knox_user_auth")
 	if err != nil {
-		return ""
+		return "", nil
 	}
 	var authResp authTokenResp
 	err = json.Unmarshal(d, &authResp)
 	if err != nil {
-		return ""
+		return "", nil
 	}
 
-	return "0u" + authResp.AccessToken
+	return "0u" + authResp.AccessToken, nil
 }
 
 func main() {


### PR DESCRIPTION
## summary

the previous multi auth implementation couldn't support TLS based authentication mechanisms. this is due to a custom TLS configuration being needed for the client and the implementation relying on the first certificate to be the client cert.

## testing

added unit tests to ensure that the override client is called