### PR TITLE
feat: improve the unauthorized error message for multi-principal

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -254,7 +254,7 @@ func TestGetKeyWithMultipleAuth(t *testing.T) {
 // TestNoAuthPrincipals tests the case where no auth handlers are available
 func TestNoAuthPrincipals(t *testing.T) {
 	// Create a test server - won't be used since auth fails before request is made
-	resp, err := buildErrorResponse(UnauthenticatedCode, "")
+	resp, err := buildErrorResponse(UnauthenticatedCode, nil)
 	if err != nil {
 		t.Fatalf("%s is not nil", err)
 	}
@@ -292,7 +292,7 @@ func TestNoAuthPrincipals(t *testing.T) {
 // TestOnlyUnauthPrincipals tests the case where a principal is provided but it is unauthorized
 func TestOnlyUnauthPrincipals(t *testing.T) {
 	// Create a test server which returns an unauthorized error
-	resp, err := buildErrorResponse(UnauthorizedCode, "")
+	resp, err := buildErrorResponse(UnauthorizedCode, nil)
 	if err != nil {
 		t.Fatalf("%s is not nil", err)
 	}


### PR DESCRIPTION
## summary

Currently, if we *only* receive unauthorized error code from the Knox server then `getHTTPData` would return no error but also have no data in the response. This would case an error message `Error getting key: invalid key content for the remote key` to be rendered to the user.

This PR proposes a slight improvement for this and ensures that if no principal is provided, we still return the existing error message `Error getting key: No authentication data given...` but if there are attempted principals and they all fail then we get the error message `Unsuccessful authorization. No attempted principals were able to perform the requested operation.` instead.

## Test Plan

Integration tested via the client and added a unit test to catch this behavior.
