### PR TITLE
server: allow service principals (SPIFFE) to create keys

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -137,12 +137,12 @@ func getKeysHandler(m KeyManager, principal knox.Principal, parameters map[strin
 // key ID, base64 encoded data, and JSON encoded ACL.
 // It returns the key version ID of the original Primary key version.
 // The route for this handler is POST /v0/keys/
-// The postKeysHandler must be a User.
+// The postKeysHandler requires a User or Service principal.
 func postKeysHandler(m KeyManager, principal knox.Principal, parameters map[string]string) (interface{}, *HTTPError) {
 
 	// Authorize
-	if !auth.IsUser(principal) {
-		return nil, errF(knox.UnauthorizedCode, fmt.Sprintf("Must be a user to create keys, principal is %s", principal.GetID()))
+	if !auth.IsUser(principal) && !auth.IsService(principal) {
+		return nil, errF(knox.UnauthorizedCode, fmt.Sprintf("Must be a user or service to create keys, principal is %s", principal.GetID()))
 	}
 
 	keyID, keyIDOK := parameters["id"]

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -160,6 +160,23 @@ func TestPostKeys(t *testing.T) {
 	}
 }
 
+func TestPostKeysServicePrincipal(t *testing.T) {
+	m, _ := makeDB()
+	svc := auth.NewService("pin220.com", "k8s/soxpiispinner/snowflake")
+	_, err := postKeysHandler(m, svc, map[string]string{"id": "svc_key1", "data": "MQ=="})
+	if err != nil {
+		t.Fatalf("Service principal should be allowed to create keys, got: %+v", err)
+	}
+	_, err = postKeysHandler(m, svc, map[string]string{"id": "svc_key2", "data": "MQ==", "acl": "[]"})
+	if err != nil {
+		t.Fatalf("Service principal should be allowed to create keys with empty ACL, got: %+v", err)
+	}
+	_, err = postKeysHandler(m, svc, map[string]string{"id": "svc_key1", "data": "MQ=="})
+	if err == nil {
+		t.Fatal("Expected err for duplicate key")
+	}
+}
+
 func TestGetKey(t *testing.T) {
 	m, _ := makeDB()
 	machine := auth.NewMachine("MrRoboto")


### PR DESCRIPTION
## Summary

Knox currently restricts key creation (`POST /v0/keys/`) to user principals only via a hardcoded `auth.IsUser()` check in `postKeysHandler`. This prevents automated services authenticated via SPIFFE from programmatically creating Knox keys, requiring manual human intervention for every new key.

This change relaxes the authorization gate to accept both user and service principals (`auth.IsUser || auth.IsService`). Machine principals remain blocked.

## Motivation

Automated workflows (e.g., Airflow DAGs provisioning Snowflake service accounts) need to create Knox keys to store credentials. These workflows authenticate via SPIFFE but hit the `IsUser` gate:
