### PR TITLE
server side: configurable service principal key creation via allowlist

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -378,7 +378,7 @@ func newKeyVersion(d []byte, s knox.VersionStatus) knox.KeyVersion {
 	return version
 }
 
-// NewKey creates a new Key with correctly set defaults.
+// newKey creates a new Key with correctly set defaults.
 func newKey(id string, acl knox.ACL, d []byte, u knox.Principal) knox.Key {
 	key := knox.Key{}
 	key.ID = id

--- a/server/api.go
+++ b/server/api.go
@@ -6,12 +6,14 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
 
 	"github.com/pinterest/knox"
 	"github.com/pinterest/knox/log"
+	"github.com/pinterest/knox/server/auth"
 	"github.com/pinterest/knox/server/keydb"
 )
 
@@ -319,6 +321,52 @@ func AddPrincipalValidator(validator knox.PrincipalValidator) {
 	extraPrincipalValidators = append(extraPrincipalValidators, validator)
 }
 
+// ServiceKeyCreationConfig defines the policy for allowing a non-user
+// principal (e.g. a SPIFFE service) to create keys.
+type ServiceKeyCreationConfig struct {
+	// SpiffePrefix is the required prefix of the service principal's ID.
+	SpiffePrefix string
+	// KeyPrefix is the required prefix of the key ID being created.
+	KeyPrefix string
+	// Owner is the person or group responsible for keys created by this service.
+	Owner string
+	// OwnerPrincipalType is the Knox principal type for the owner (e.g. User or UserGroup).
+	OwnerPrincipalType knox.PrincipalType
+	// NimbusProject is metadata identifying the project associated with this service.
+	NimbusProject string
+	// MaxKeysPerHour caps how many keys this service can create per hour. 0 = unlimited.
+	MaxKeysPerHour int
+}
+
+var serviceKeyCreationConfigs []ServiceKeyCreationConfig
+
+// AddServiceKeyCreationConfig registers a policy that allows a matching
+// service principal to create keys. If no configs are registered the default
+// behavior (user-only) is preserved.
+func AddServiceKeyCreationConfig(cfg ServiceKeyCreationConfig) {
+	serviceKeyCreationConfigs = append(serviceKeyCreationConfigs, cfg)
+}
+
+// MatchServiceKeyCreation checks whether principal+keyID match any registered
+// config. Returns the matching config and true, or a zero value and false.
+func MatchServiceKeyCreation(principal knox.Principal, keyID string) (ServiceKeyCreationConfig, bool) {
+	if !auth.IsService(principal) {
+		return ServiceKeyCreationConfig{}, false
+	}
+	id := principal.GetID()
+	for _, cfg := range serviceKeyCreationConfigs {
+		if strings.HasPrefix(id, cfg.SpiffePrefix) && strings.HasPrefix(keyID, cfg.KeyPrefix) {
+			return cfg, true
+		}
+	}
+	return ServiceKeyCreationConfig{}, false
+}
+
+// ResetServiceKeyCreationConfigs clears all registered configs (for testing).
+func ResetServiceKeyCreationConfigs() {
+	serviceKeyCreationConfigs = nil
+}
+
 // newKeyVersion creates a new KeyVersion with correctly set defaults.
 func newKeyVersion(d []byte, s knox.VersionStatus) knox.KeyVersion {
 	version := knox.KeyVersion{}
@@ -335,7 +383,11 @@ func newKey(id string, acl knox.ACL, d []byte, u knox.Principal) knox.Key {
 	key := knox.Key{}
 	key.ID = id
 
-	creatorAccess := knox.Access{ID: u.GetID(), AccessType: knox.Admin, Type: knox.User}
+	creatorType := knox.PrincipalType(knox.User)
+	if auth.IsService(u) {
+		creatorType = knox.Service
+	}
+	creatorAccess := knox.Access{ID: u.GetID(), AccessType: knox.Admin, Type: creatorType}
 	key.ACL = acl.Add(creatorAccess)
 	for _, a := range defaultAccess {
 		key.ACL = key.ACL.Add(a)

--- a/server/api.go
+++ b/server/api.go
@@ -367,11 +367,18 @@ type PrefixServiceKeyCreationAuthorizer struct {
 	policies []ServiceKeyCreationPolicy
 }
 
-// AddPolicy registers a policy. Returns an error if Owner is not specified,
-// because keys without a human admin would break Knox's ownership invariant.
+// AddPolicy registers a policy. Returns an error if:
+//   - Owner is not specified (keys without a human admin would break Knox's
+//     ownership invariant), or
+//   - SpiffePrefix is not a well-formed SPIFFE prefix as validated by
+//     knox.ServicePrefix.IsValidPrincipal (must be a spiffe:// URL ending in
+//     "/" so prefix matching respects path-component boundaries).
 func (a *PrefixServiceKeyCreationAuthorizer) AddPolicy(p ServiceKeyCreationPolicy) error {
 	if p.Owner.ID == "" {
 		return fmt.Errorf("service key creation policy must specify an Owner with a non-empty ID")
+	}
+	if err := knox.PrincipalType(knox.ServicePrefix).IsValidPrincipal(p.SpiffePrefix, nil); err != nil {
+		return fmt.Errorf("invalid SpiffePrefix %q: %w", p.SpiffePrefix, err)
 	}
 	a.policies = append(a.policies, p)
 	return nil

--- a/server/api.go
+++ b/server/api.go
@@ -321,50 +321,76 @@ func AddPrincipalValidator(validator knox.PrincipalValidator) {
 	extraPrincipalValidators = append(extraPrincipalValidators, validator)
 }
 
-// ServiceKeyCreationConfig defines the policy for allowing a non-user
-// principal (e.g. a SPIFFE service) to create keys.
-type ServiceKeyCreationConfig struct {
-	// SpiffePrefix is the required prefix of the service principal's ID.
+// ServiceKeyCreationAuthorizer decides whether a non-user principal (e.g. a
+// SPIFFE service) is allowed to create a given key. Implementations hold their
+// own state (allowlists, rate limiters, project metadata, etc.) on their own
+// struct, so Knox itself does not own mutable package-level state.
+//
+// Authorize returns the owner Access that should be added as an Admin on the
+// newly created key to preserve the invariant that every key has a human
+// admin. If ok is false the key creation is rejected.
+type ServiceKeyCreationAuthorizer interface {
+	Authorize(principal knox.Principal, keyID string) (owner knox.Access, ok bool)
+}
+
+// serviceKeyCreationAuthorizer is the single pluggable hook for non-user key
+// creation. When nil (the default), only users may create keys.
+var serviceKeyCreationAuthorizer ServiceKeyCreationAuthorizer
+
+// SetServiceKeyCreationAuthorizer installs the authorizer invoked when a
+// non-user principal attempts to create a key. Pass nil to disable non-user
+// creation (the default).
+func SetServiceKeyCreationAuthorizer(a ServiceKeyCreationAuthorizer) {
+	serviceKeyCreationAuthorizer = a
+}
+
+// ServiceKeyCreationPolicy is a single entry in the reference
+// PrefixServiceKeyCreationAuthorizer implementation. It matches a service
+// principal by SPIFFE ID prefix and a key by key-ID prefix, and names the
+// human Owner that becomes an Admin on keys created under the policy.
+//
+// Metadata is free-form key/value data that callers may use for their own
+// bookkeeping (e.g. project name, rate-limit bucket). It is not interpreted
+// by Knox.
+type ServiceKeyCreationPolicy struct {
 	SpiffePrefix string
-	// KeyPrefix is the required prefix of the key ID being created.
-	KeyPrefix string
-	// Owner is the person or group responsible for keys created by this service.
-	Owner string
-	// OwnerPrincipalType is the Knox principal type for the owner (e.g. User or UserGroup).
-	OwnerPrincipalType knox.PrincipalType
-	// NimbusProject is metadata identifying the project associated with this service.
-	NimbusProject string
-	// MaxKeysPerHour caps how many keys this service can create per hour. 0 = unlimited.
-	MaxKeysPerHour int
+	KeyPrefix    string
+	Owner        knox.Access
+	Metadata     map[string]string
 }
 
-var serviceKeyCreationConfigs []ServiceKeyCreationConfig
-
-// AddServiceKeyCreationConfig registers a policy that allows a matching
-// service principal to create keys. If no configs are registered the default
-// behavior (user-only) is preserved.
-func AddServiceKeyCreationConfig(cfg ServiceKeyCreationConfig) {
-	serviceKeyCreationConfigs = append(serviceKeyCreationConfigs, cfg)
+// PrefixServiceKeyCreationAuthorizer is a reference ServiceKeyCreationAuthorizer
+// that matches services by SPIFFE prefix and keys by key-ID prefix. Consumers
+// who need richer behavior (rate limiting, dynamic config, etc.) should
+// implement ServiceKeyCreationAuthorizer themselves.
+type PrefixServiceKeyCreationAuthorizer struct {
+	policies []ServiceKeyCreationPolicy
 }
 
-// MatchServiceKeyCreation checks whether principal+keyID match any registered
-// config. Returns the matching config and true, or a zero value and false.
-func MatchServiceKeyCreation(principal knox.Principal, keyID string) (ServiceKeyCreationConfig, bool) {
+// AddPolicy registers a policy. Returns an error if Owner is not specified,
+// because keys without a human admin would break Knox's ownership invariant.
+func (a *PrefixServiceKeyCreationAuthorizer) AddPolicy(p ServiceKeyCreationPolicy) error {
+	if p.Owner.ID == "" {
+		return fmt.Errorf("service key creation policy must specify an Owner with a non-empty ID")
+	}
+	a.policies = append(a.policies, p)
+	return nil
+}
+
+// Authorize implements ServiceKeyCreationAuthorizer.
+func (a *PrefixServiceKeyCreationAuthorizer) Authorize(principal knox.Principal, keyID string) (knox.Access, bool) {
 	if !auth.IsService(principal) {
-		return ServiceKeyCreationConfig{}, false
+		return knox.Access{}, false
 	}
 	id := principal.GetID()
-	for _, cfg := range serviceKeyCreationConfigs {
-		if strings.HasPrefix(id, cfg.SpiffePrefix) && strings.HasPrefix(keyID, cfg.KeyPrefix) {
-			return cfg, true
+	for _, p := range a.policies {
+		if strings.HasPrefix(id, p.SpiffePrefix) && strings.HasPrefix(keyID, p.KeyPrefix) {
+			owner := p.Owner
+			owner.AccessType = knox.Admin
+			return owner, true
 		}
 	}
-	return ServiceKeyCreationConfig{}, false
-}
-
-// ResetServiceKeyCreationConfigs clears all registered configs (for testing).
-func ResetServiceKeyCreationConfigs() {
-	serviceKeyCreationConfigs = nil
+	return knox.Access{}, false
 }
 
 // newKeyVersion creates a new KeyVersion with correctly set defaults.
@@ -379,7 +405,11 @@ func newKeyVersion(d []byte, s knox.VersionStatus) knox.KeyVersion {
 }
 
 // newKey creates a new Key with correctly set defaults.
-func newKey(id string, acl knox.ACL, d []byte, u knox.Principal) knox.Key {
+//
+// The creator is always added as an Admin. Any extraAdmins (e.g. a human
+// owner for service-created keys) are also added as Admins so that the
+// invariant "every key has a human admin" is preserved in a single place.
+func newKey(id string, acl knox.ACL, d []byte, u knox.Principal, extraAdmins ...knox.Access) knox.Key {
 	key := knox.Key{}
 	key.ID = id
 
@@ -390,6 +420,13 @@ func newKey(id string, acl knox.ACL, d []byte, u knox.Principal) knox.Key {
 	creatorAccess := knox.Access{ID: u.GetID(), AccessType: knox.Admin, Type: creatorType}
 	key.ACL = acl.Add(creatorAccess)
 	for _, a := range defaultAccess {
+		key.ACL = key.ACL.Add(a)
+	}
+	for _, a := range extraAdmins {
+		if a.ID == "" {
+			continue
+		}
+		a.AccessType = knox.Admin
 		key.ACL = key.ACL.Add(a)
 	}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -137,27 +137,31 @@ func getKeysHandler(m KeyManager, principal knox.Principal, parameters map[strin
 // key ID, base64 encoded data, and JSON encoded ACL.
 // It returns the key version ID of the original Primary key version.
 // The route for this handler is POST /v0/keys/
-// Users can always create keys. Service principals can create keys only if a
-// matching ServiceKeyCreationConfig has been registered.
+// Users can always create keys. Non-user principals (e.g. services) can
+// create keys only if a ServiceKeyCreationAuthorizer has been installed and
+// authorizes the (principal, keyID) pair.
 func postKeysHandler(m KeyManager, principal knox.Principal, parameters map[string]string) (interface{}, *HTTPError) {
 
-	keyID := parameters["id"]
-
-	// Authorize: users are always allowed; services need a matching config.
-	var ownerACL knox.ACL
-	if !auth.IsUser(principal) {
-		cfg, allowed := MatchServiceKeyCreation(principal, keyID)
-		if !allowed {
-			return nil, errF(knox.UnauthorizedCode, fmt.Sprintf("Principal %s is not authorized to create keys", principal.GetID()))
-		}
-		if cfg.Owner != "" {
-			ownerACL = knox.ACL{{ID: cfg.Owner, AccessType: knox.Admin, Type: cfg.OwnerPrincipalType}}
-		}
-	}
-
-	if keyID == "" {
+	keyID, keyIDOK := parameters["id"]
+	if !keyIDOK || keyID == "" {
 		return nil, errF(knox.NoKeyIDCode, "Missing parameter 'id'")
 	}
+
+	var extraAdmins []knox.Access
+	if !auth.IsUser(principal) {
+		if serviceKeyCreationAuthorizer == nil {
+			return nil, errF(knox.UnauthorizedCode, fmt.Sprintf("Must be a user to create keys, principal is %s", principal.GetID()))
+		}
+		owner, ok := serviceKeyCreationAuthorizer.Authorize(principal, keyID)
+		if !ok {
+			return nil, errF(knox.UnauthorizedCode, fmt.Sprintf("Principal %s is not authorized to create keys", principal.GetID()))
+		}
+		if owner.ID == "" {
+			return nil, errF(knox.UnauthorizedCode, fmt.Sprintf("Principal %s is authorized but has no owner configured", principal.GetID()))
+		}
+		extraAdmins = append(extraAdmins, owner)
+	}
+
 	data, dataOK := parameters["data"]
 	if !dataOK {
 		return nil, errF(knox.NoKeyDataCode, "Missing parameter 'data'")
@@ -180,11 +184,7 @@ func postKeysHandler(m KeyManager, principal knox.Principal, parameters map[stri
 		return nil, errF(knox.BadRequestDataCode, decodeErr.Error())
 	}
 
-	// Create and add new key; inject owner ACL for service-created keys.
-	key := newKey(keyID, acl, decodedData, principal)
-	for _, a := range ownerACL {
-		key.ACL = key.ACL.Add(a)
-	}
+	key := newKey(keyID, acl, decodedData, principal, extraAdmins...)
 	err := m.AddNewKey(&key)
 	if err != nil {
 		if err == knox.ErrKeyExists {

--- a/server/routes.go
+++ b/server/routes.go
@@ -137,16 +137,25 @@ func getKeysHandler(m KeyManager, principal knox.Principal, parameters map[strin
 // key ID, base64 encoded data, and JSON encoded ACL.
 // It returns the key version ID of the original Primary key version.
 // The route for this handler is POST /v0/keys/
-// The postKeysHandler must be a User.
+// Users can always create keys. Service principals can create keys only if a
+// matching ServiceKeyCreationConfig has been registered.
 func postKeysHandler(m KeyManager, principal knox.Principal, parameters map[string]string) (interface{}, *HTTPError) {
 
-	// Authorize
+	keyID := parameters["id"]
+
+	// Authorize: users are always allowed; services need a matching config.
+	var ownerACL knox.ACL
 	if !auth.IsUser(principal) {
-		return nil, errF(knox.UnauthorizedCode, fmt.Sprintf("Must be a user to create keys, principal is %s", principal.GetID()))
+		cfg, allowed := MatchServiceKeyCreation(principal, keyID)
+		if !allowed {
+			return nil, errF(knox.UnauthorizedCode, fmt.Sprintf("Principal %s is not authorized to create keys", principal.GetID()))
+		}
+		if cfg.Owner != "" {
+			ownerACL = knox.ACL{{ID: cfg.Owner, AccessType: knox.Admin, Type: cfg.OwnerPrincipalType}}
+		}
 	}
 
-	keyID, keyIDOK := parameters["id"]
-	if !keyIDOK {
+	if keyID == "" {
 		return nil, errF(knox.NoKeyIDCode, "Missing parameter 'id'")
 	}
 	data, dataOK := parameters["data"]
@@ -171,8 +180,11 @@ func postKeysHandler(m KeyManager, principal knox.Principal, parameters map[stri
 		return nil, errF(knox.BadRequestDataCode, decodeErr.Error())
 	}
 
-	// Create and add new key
+	// Create and add new key; inject owner ACL for service-created keys.
 	key := newKey(keyID, acl, decodedData, principal)
+	for _, a := range ownerACL {
+		key.ACL = key.ACL.Add(a)
+	}
 	err := m.AddNewKey(&key)
 	if err != nil {
 		if err == knox.ErrKeyExists {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -163,7 +163,7 @@ func TestPostKeys(t *testing.T) {
 
 func TestPostKeysServiceWithAuthorizer(t *testing.T) {
 	m, _ := makeDB()
-	svc := auth.NewService("example.com", "service/test-svc")
+	svc := auth.NewService("example.com", "service/test-svc/v1")
 	machine := auth.NewMachine("test-machine")
 
 	// Without any authorizer installed, non-user principals are rejected
@@ -175,7 +175,7 @@ func TestPostKeysServiceWithAuthorizer(t *testing.T) {
 
 	authz := &PrefixServiceKeyCreationAuthorizer{}
 	if addErr := authz.AddPolicy(ServiceKeyCreationPolicy{
-		SpiffePrefix: "spiffe://example.com/service/test-svc",
+		SpiffePrefix: "spiffe://example.com/service/test-svc/",
 		KeyPrefix:    "test:project:",
 		Owner:        knox.Access{ID: "test-owners", Type: knox.UserGroup},
 		Metadata:     map[string]string{"project": "test-project"},
@@ -214,7 +214,7 @@ func TestPostKeysServiceWithAuthorizer(t *testing.T) {
 	}
 
 	// Non-matching SPIFFE is rejected.
-	otherSvc := auth.NewService("example.com", "service/other-svc")
+	otherSvc := auth.NewService("example.com", "service/other-svc/v1")
 	_, err = postKeysHandler(m, otherSvc, map[string]string{"id": "test:project:key2", "data": "MQ=="})
 	if err == nil {
 		t.Fatal("Expected err for non-matching SPIFFE")
@@ -230,11 +230,37 @@ func TestPostKeysServiceWithAuthorizer(t *testing.T) {
 func TestPrefixServiceKeyCreationAuthorizerRequiresOwner(t *testing.T) {
 	authz := &PrefixServiceKeyCreationAuthorizer{}
 	err := authz.AddPolicy(ServiceKeyCreationPolicy{
-		SpiffePrefix: "spiffe://example.com/service/test-svc",
+		SpiffePrefix: "spiffe://example.com/service/test-svc/",
 		KeyPrefix:    "test:project:",
 	})
 	if err == nil {
 		t.Fatal("Expected AddPolicy to reject a policy with no Owner")
+	}
+}
+
+func TestPrefixServiceKeyCreationAuthorizerValidatesSpiffePrefix(t *testing.T) {
+	owner := knox.Access{ID: "test-owners", Type: knox.UserGroup}
+
+	cases := []struct {
+		name   string
+		prefix string
+	}{
+		{"empty", ""},
+		{"not a spiffe url", "http://example.com/service/"},
+		{"missing trailing slash", "spiffe://example.com/service/test-svc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			authz := &PrefixServiceKeyCreationAuthorizer{}
+			err := authz.AddPolicy(ServiceKeyCreationPolicy{
+				SpiffePrefix: tc.prefix,
+				KeyPrefix:    "test:project:",
+				Owner:        owner,
+			})
+			if err == nil {
+				t.Fatalf("Expected AddPolicy to reject SpiffePrefix %q", tc.prefix)
+			}
+		})
 	}
 }
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -160,7 +160,6 @@ func TestPostKeys(t *testing.T) {
 	}
 }
 
-
 func TestPostKeysServiceWithAuthorizer(t *testing.T) {
 	m, _ := makeDB()
 	svc := auth.NewService("example.com", "service/test-svc/v1")

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -161,30 +161,50 @@ func TestPostKeys(t *testing.T) {
 }
 
 
-func TestPostKeysServiceWithConfig(t *testing.T) {
+func TestPostKeysServiceWithAuthorizer(t *testing.T) {
 	m, _ := makeDB()
-	svc := auth.NewService("pin220.com", "k8s/soxpiispinner/snowflake")
-	machine := auth.NewMachine("MrRoboto")
+	svc := auth.NewService("example.com", "service/test-svc")
+	machine := auth.NewMachine("test-machine")
 
-	// Without any config registered, services are rejected (backwards compat).
-	_, err := postKeysHandler(m, svc, map[string]string{"id": "it:edp:snowflake:test1", "data": "MQ=="})
+	// Without any authorizer installed, non-user principals are rejected
+	// (preserving the pre-existing user-only default).
+	_, err := postKeysHandler(m, svc, map[string]string{"id": "test:project:key1", "data": "MQ=="})
 	if err == nil {
-		t.Fatal("Expected err when no service config is registered")
+		t.Fatal("Expected err when no service authorizer is installed")
 	}
 
-	AddServiceKeyCreationConfig(ServiceKeyCreationConfig{
-		SpiffePrefix:       "spiffe://pin220.com/k8s/soxpiispinner/",
-		KeyPrefix:          "it:edp:snowflake:",
-		Owner:              "it-edp",
-		OwnerPrincipalType: knox.UserGroup,
-		NimbusProject:      "snowflake",
-	})
-	defer ResetServiceKeyCreationConfigs()
+	authz := &PrefixServiceKeyCreationAuthorizer{}
+	if addErr := authz.AddPolicy(ServiceKeyCreationPolicy{
+		SpiffePrefix: "spiffe://example.com/service/test-svc",
+		KeyPrefix:    "test:project:",
+		Owner:        knox.Access{ID: "test-owners", Type: knox.UserGroup},
+		Metadata:     map[string]string{"project": "test-project"},
+	}); addErr != nil {
+		t.Fatalf("AddPolicy returned unexpected error: %v", addErr)
+	}
+	SetServiceKeyCreationAuthorizer(authz)
+	defer SetServiceKeyCreationAuthorizer(nil)
 
-	// Matching service + key prefix succeeds.
-	_, err = postKeysHandler(m, svc, map[string]string{"id": "it:edp:snowflake:test1", "data": "MQ=="})
+	// Matching service + key prefix succeeds and the owner is recorded as admin.
+	i, err := postKeysHandler(m, svc, map[string]string{"id": "test:project:key1", "data": "MQ=="})
 	if err != nil {
-		t.Fatalf("Expected success for matching service config, got: %+v", err)
+		t.Fatalf("Expected success for matching policy, got: %+v", err)
+	}
+	if _, ok := i.(uint64); !ok {
+		t.Fatalf("Expected uint64 version id, got %T", i)
+	}
+	k, kerr := m.GetKey("test:project:key1", knox.Active)
+	if kerr != nil {
+		t.Fatalf("Could not fetch newly created key: %v", kerr)
+	}
+	foundOwnerAdmin := false
+	for _, a := range k.ACL {
+		if a.ID == "test-owners" && a.Type == knox.UserGroup && a.AccessType == knox.Admin {
+			foundOwnerAdmin = true
+		}
+	}
+	if !foundOwnerAdmin {
+		t.Fatalf("Expected owner 'test-owners' to be Admin on ACL, got %+v", k.ACL)
 	}
 
 	// Non-matching key prefix is rejected.
@@ -194,16 +214,27 @@ func TestPostKeysServiceWithConfig(t *testing.T) {
 	}
 
 	// Non-matching SPIFFE is rejected.
-	otherSvc := auth.NewService("pin220.com", "k8s/otherspinner/service")
-	_, err = postKeysHandler(m, otherSvc, map[string]string{"id": "it:edp:snowflake:test2", "data": "MQ=="})
+	otherSvc := auth.NewService("example.com", "service/other-svc")
+	_, err = postKeysHandler(m, otherSvc, map[string]string{"id": "test:project:key2", "data": "MQ=="})
 	if err == nil {
 		t.Fatal("Expected err for non-matching SPIFFE")
 	}
 
 	// Machine principals are always rejected.
-	_, err = postKeysHandler(m, machine, map[string]string{"id": "it:edp:snowflake:test3", "data": "MQ=="})
+	_, err = postKeysHandler(m, machine, map[string]string{"id": "test:project:key3", "data": "MQ=="})
 	if err == nil {
 		t.Fatal("Expected err for machine principal")
+	}
+}
+
+func TestPrefixServiceKeyCreationAuthorizerRequiresOwner(t *testing.T) {
+	authz := &PrefixServiceKeyCreationAuthorizer{}
+	err := authz.AddPolicy(ServiceKeyCreationPolicy{
+		SpiffePrefix: "spiffe://example.com/service/test-svc",
+		KeyPrefix:    "test:project:",
+	})
+	if err == nil {
+		t.Fatal("Expected AddPolicy to reject a policy with no Owner")
 	}
 }
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -160,6 +160,53 @@ func TestPostKeys(t *testing.T) {
 	}
 }
 
+
+func TestPostKeysServiceWithConfig(t *testing.T) {
+	m, _ := makeDB()
+	svc := auth.NewService("pin220.com", "k8s/soxpiispinner/snowflake")
+	machine := auth.NewMachine("MrRoboto")
+
+	// Without any config registered, services are rejected (backwards compat).
+	_, err := postKeysHandler(m, svc, map[string]string{"id": "it:edp:snowflake:test1", "data": "MQ=="})
+	if err == nil {
+		t.Fatal("Expected err when no service config is registered")
+	}
+
+	AddServiceKeyCreationConfig(ServiceKeyCreationConfig{
+		SpiffePrefix:       "spiffe://pin220.com/k8s/soxpiispinner/",
+		KeyPrefix:          "it:edp:snowflake:",
+		Owner:              "it-edp",
+		OwnerPrincipalType: knox.UserGroup,
+		NimbusProject:      "snowflake",
+	})
+	defer ResetServiceKeyCreationConfigs()
+
+	// Matching service + key prefix succeeds.
+	_, err = postKeysHandler(m, svc, map[string]string{"id": "it:edp:snowflake:test1", "data": "MQ=="})
+	if err != nil {
+		t.Fatalf("Expected success for matching service config, got: %+v", err)
+	}
+
+	// Non-matching key prefix is rejected.
+	_, err = postKeysHandler(m, svc, map[string]string{"id": "other:prefix:key", "data": "MQ=="})
+	if err == nil {
+		t.Fatal("Expected err for non-matching key prefix")
+	}
+
+	// Non-matching SPIFFE is rejected.
+	otherSvc := auth.NewService("pin220.com", "k8s/otherspinner/service")
+	_, err = postKeysHandler(m, otherSvc, map[string]string{"id": "it:edp:snowflake:test2", "data": "MQ=="})
+	if err == nil {
+		t.Fatal("Expected err for non-matching SPIFFE")
+	}
+
+	// Machine principals are always rejected.
+	_, err = postKeysHandler(m, machine, map[string]string{"id": "it:edp:snowflake:test3", "data": "MQ=="})
+	if err == nil {
+		t.Fatal("Expected err for machine principal")
+	}
+}
+
 func TestGetKey(t *testing.T) {
 	m, _ := makeDB()
 	machine := auth.NewMachine("MrRoboto")


### PR DESCRIPTION
## Summary

Currently, only user principals (LDAP users) can create Knox keys. This PR adds a configurable allowlist mechanism so that service principals (e.g. SPIFFE-authenticated services) can also create keys, scoped to specific key prefixes.

- Add `ServiceKeyCreationConfig` struct and `AddServiceKeyCreationConfig()` registration API in `api.go`
- Update `postKeysHandler` to check registered configs when the caller is not a user
- Automatically set the correct `PrincipalType` (User vs Service) on the creator ACL entry
- Optionally inject an owner (person/group) into the key's ACL at creation time for auditability
- Include `MaxKeysPerHour` and `NimbusProject` fields for downstream rate limiting and metadata

By default, no configs are registered and behavior is identical to today (user-only). This is fully backward compatible.

## Motivation

Automated infrastructure (e.g. Airflow DAGs with SPIFFE identities) needs to programmatically create Knox keys for provisioning service accounts. Today this requires a human to pre-create every key manually. This change enables that automation while keeping key creation locked down to explicitly approved service+namespace pairs.

## Test plan

- [x] `TestPostKeys` — existing user-based key creation still works
- [x] `TestPostKeysServiceWithConfig` — new test covering:
  - Service rejected when no config registered (backwards compat)
  - Service allowed when SPIFFE + key prefix match a registered config
  - Service rejected when key prefix doesn't match
  - Service rejected when SPIFFE doesn't match
  - Machine principals always rejected
- [x] Full suite: `go test ./...` passes (all packages)
<img width="510" height="335" alt="Screenshot 2026-04-08 at 9 49 53 PM" src="https://github.com/user-attachments/assets/7416d044-cd9b-487e-978e-c8b51cc04e21" />
<img width="1042" height="719" alt="Screenshot 2026-04-08 at 9 49 46 PM" src="https://github.com/user-attachments/assets/587026a6-7d0a-4b42-aad5-333baa9a80b1" />

