### PR TITLE
auth: make IsService/IsUser/IsMachine see through PrincipalMux

### DIFF
--- a/knox.go
+++ b/knox.go
@@ -572,6 +572,16 @@ func (p PrincipalMux) Default() Principal {
 	return p.defaultPrincipal
 }
 
+// Principals returns all the constituent principals being muxed, including
+// the default. Order is not guaranteed (the underlying storage is a map).
+func (p PrincipalMux) Principals() []Principal {
+	principals := make([]Principal, 0, len(p.allPrincipals))
+	for _, principal := range p.allPrincipals {
+		principals = append(principals, principal)
+	}
+	return principals
+}
+
 // Raw returns the raw version of all the principals.
 func (p PrincipalMux) Raw() []RawPrincipal {
 	raw := []RawPrincipal{}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -318,22 +318,57 @@ type httpClient interface {
 	Do(req *http.Request) (resp *http.Response, err error)
 }
 
-// IsUser returns true if the principal, or first principal in the case of mux, is a user.
+// IsUser returns true if the principal is a user, or if the principal is a
+// PrincipalMux that contains at least one user sub-principal.
 func IsUser(p knox.Principal) bool {
-	if mux, ok := p.(knox.PrincipalMux); ok {
-		p = mux.Default()
+	if _, ok := p.(user); ok {
+		return true
 	}
-	_, ok := p.(user)
-	return ok
+	if mux, ok := p.(knox.PrincipalMux); ok {
+		for _, sub := range mux.Principals() {
+			if _, ok := sub.(user); ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
-// IsService returns true if the principal, or first principal in the case of mux, is a service.
+// IsService returns true if the principal is a service, or if the principal is
+// a PrincipalMux that contains at least one service sub-principal.
+//
+// This sees through PrincipalMux deliberately: in multi-provider auth chains a
+// real service principal is often wrapped in a mux whose default is a different
+// principal type, so a strict default-only check would incorrectly reject real
+// service requests in any code path that gates on IsService.
 func IsService(p knox.Principal) bool {
-	if mux, ok := p.(knox.PrincipalMux); ok {
-		p = mux.Default()
+	if _, ok := p.(service); ok {
+		return true
 	}
-	_, ok := p.(service)
-	return ok
+	if mux, ok := p.(knox.PrincipalMux); ok {
+		for _, sub := range mux.Principals() {
+			if _, ok := sub.(service); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsMachine returns true if the principal is a machine, or if the principal is
+// a PrincipalMux that contains at least one machine sub-principal.
+func IsMachine(p knox.Principal) bool {
+	if _, ok := p.(machine); ok {
+		return true
+	}
+	if mux, ok := p.(knox.PrincipalMux); ok {
+		for _, sub := range mux.Principals() {
+			if _, ok := sub.(machine); ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type stringSet map[string]struct{}

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -164,22 +164,141 @@ func TestPrincipalMuxType(t *testing.T) {
 }
 
 func TestPrincipalMuxUserOrService(t *testing.T) {
+	// IsUser/IsService should match if *any* sub-principal in the mux is of
+	// the target type, not just the default. In multi-provider auth chains a
+	// real service principal is often wrapped in a mux whose default is a
+	// different principal type, and downstream code that gates on these
+	// predicates (e.g. ServiceKeyCreationAuthorizer) would otherwise reject
+	// real service requests.
 	u := NewUser("test", []string{"returntrue"})
 	s := NewService("example.com", "serviceA")
 	userMux := knox.NewPrincipalMux(u, map[string]knox.Principal{"foo": u, "bar": s})
 	serviceMux := knox.NewPrincipalMux(s, map[string]knox.Principal{"foo": u, "bar": s})
 
 	if !IsUser(userMux) {
-		t.Error("IsUser failed to identify that mux is user first.")
+		t.Error("IsUser failed to identify mux containing a user.")
 	}
-	if IsService(userMux) {
-		t.Error("IsService failed to identify that mux is user first, and thus not a service.")
+	if !IsService(userMux) {
+		t.Error("IsService failed to identify mux containing a service (default user).")
 	}
-	if IsUser(serviceMux) {
-		t.Error("IsUser failed to identify that mux is service first, and thus not a user.")
+	if !IsUser(serviceMux) {
+		t.Error("IsUser failed to identify mux containing a user (default service).")
 	}
 	if !IsService(serviceMux) {
-		t.Error("IsService failed to identify that mux is service first.")
+		t.Error("IsService failed to identify mux containing a service.")
+	}
+}
+
+func TestIsServicePrincipalMux(t *testing.T) {
+	s := NewService("pin220.com", "k8s/example/username/test")
+	mux := knox.NewPrincipalMux(s, map[string]knox.Principal{"service": s})
+
+	if !IsService(mux) {
+		t.Error("IsService(mux wrapping service) = false, want true")
+	}
+	if IsUser(mux) {
+		t.Error("IsUser(mux wrapping only service) = true, want false")
+	}
+	if IsMachine(mux) {
+		t.Error("IsMachine(mux wrapping only service) = true, want false")
+	}
+}
+
+func TestIsUserPrincipalMux(t *testing.T) {
+	u := NewUser("testuser", []string{"testgroup"})
+	mux := knox.NewPrincipalMux(u, map[string]knox.Principal{"user": u})
+
+	if !IsUser(mux) {
+		t.Error("IsUser(mux wrapping user) = false, want true")
+	}
+	if IsService(mux) {
+		t.Error("IsService(mux wrapping only user) = true, want false")
+	}
+	if IsMachine(mux) {
+		t.Error("IsMachine(mux wrapping only user) = true, want false")
+	}
+}
+
+func TestIsMachinePrincipalMux(t *testing.T) {
+	m := NewMachine("test001")
+	mux := knox.NewPrincipalMux(m, map[string]knox.Principal{"machine": m})
+
+	if !IsMachine(mux) {
+		t.Error("IsMachine(mux wrapping machine) = false, want true")
+	}
+	if IsService(mux) {
+		t.Error("IsService(mux wrapping only machine) = true, want false")
+	}
+	if IsUser(mux) {
+		t.Error("IsUser(mux wrapping only machine) = true, want false")
+	}
+}
+
+func TestIsPredicatesRawPrincipals(t *testing.T) {
+	// Fast path: predicates should also work on raw (non-mux) principals.
+	u := NewUser("testuser", nil)
+	s := NewService("example.com", "serviceA")
+	m := NewMachine("test001")
+
+	if !IsUser(u) || IsService(u) || IsMachine(u) {
+		t.Error("predicates misidentified raw user")
+	}
+	if !IsService(s) || IsUser(s) || IsMachine(s) {
+		t.Error("predicates misidentified raw service")
+	}
+	if !IsMachine(m) || IsUser(m) || IsService(m) {
+		t.Error("predicates misidentified raw machine")
+	}
+}
+
+func TestIsServicePrincipalMuxMixedSubPrincipals(t *testing.T) {
+	// mux where the default is a User but a Service is also present:
+	// IsService should still return true because a service is in the mux.
+	u := NewUser("testuser", nil)
+	s := NewService("pin220.com", "k8s/example/username/test")
+	mux := knox.NewPrincipalMux(u, map[string]knox.Principal{
+		"user":    u,
+		"service": s,
+	})
+
+	if !IsService(mux) {
+		t.Error("IsService(mux containing service) = false, want true")
+	}
+	if !IsUser(mux) {
+		t.Error("IsUser(mux containing user) = false, want true")
+	}
+	if IsMachine(mux) {
+		t.Error("IsMachine(mux without machine) = true, want false")
+	}
+}
+
+func TestPrincipalMuxPrincipals(t *testing.T) {
+	u := NewUser("testuser", nil)
+	s := NewService("example.com", "serviceA")
+	mux := knox.NewPrincipalMux(u, map[string]knox.Principal{
+		"user":    u,
+		"service": s,
+	}).(knox.PrincipalMux)
+
+	got := mux.Principals()
+	if len(got) != 2 {
+		t.Fatalf("Principals() length = %d, want 2", len(got))
+	}
+
+	hasUser, hasService := false, false
+	for _, p := range got {
+		if _, ok := p.(user); ok {
+			hasUser = true
+		}
+		if _, ok := p.(service); ok {
+			hasService = true
+		}
+	}
+	if !hasUser {
+		t.Error("Principals() did not return the user sub-principal")
+	}
+	if !hasService {
+		t.Error("Principals() did not return the service sub-principal")
 	}
 }
 


### PR DESCRIPTION
## Summary

The principal predicates `auth.IsService` and `auth.IsUser` are implemented to check only the *default* sub-principal of a `knox.PrincipalMux`. When a multi-provider auth chain wraps the authenticated principal in a mux via `knox.NewPrincipalMux`, and the default sub-principal happens to be a different type than the one the caller is trying to detect, these predicates return `false` even though a matching sub-principal is present.

This silently breaks any code path that gates on these predicates after auth. Concretely, the `ServiceKeyCreationAuthorizer` hook added in 8438e97 has the shape:

```go
func (a *PrefixServiceKeyCreationAuthorizer) Authorize(principal knox.Principal, keyID string) (knox.Access, bool) {
    if !auth.IsService(principal) {
        return knox.Access{}, false
    }
    // ...match policies...
}
```

Any custom authorizer of this shape will reject every real request when the principal is a `PrincipalMux` whose default is a non-service principal — even when `principal.GetID()` returns the expected SPIFFE id and the access logger reports `auth_type: "service"` (that field is derived from the matched provider's name, not from `IsService`, so the bug is invisible from the request log alone).

## Fix

- Keep the fast-path direct type assertion for callers that pass raw principal types.
- For `PrincipalMux`, walk `mux.Principals()` and return true if *any* constituent principal matches the target type (default and non-default alike).
- Add `IsMachine` for symmetry — it didn't previously exist.
- Add a `Principals()` accessor on `knox.PrincipalMux` that returns its constituent principals as `[]knox.Principal`. The underlying field is unexported and there was no existing accessor that returned the full set; `Default()` only returns one and `Raw()` returns `RawPrincipal`s.

## Test plan

- [x] Updated the existing `TestPrincipalMuxUserOrService`, which was encoding the old default-only behavior, to reflect the new "any sub-principal matches" semantics. **This is a behavior change in the predicates; flagging it explicitly.** The old behavior is what caused the bug above, so the assertions had to flip.
- [x] Added `TestIsServicePrincipalMux`, `TestIsUserPrincipalMux`, `TestIsMachinePrincipalMux`: each wraps a single principal type in a mux and asserts only the matching predicate returns true.
- [x] Added `TestIsPredicatesRawPrincipals`: asserts the fast path still works on raw (non-mux) principals.
- [x] Added `TestIsServicePrincipalMuxMixedSubPrincipals`: a mux whose default is a `User` but which also contains a `Service` — `IsService` and `IsUser` both return true, `IsMachine` returns false. This is the exact production failure mode.
- [x] Added `TestPrincipalMuxPrincipals`: verifies the new `Principals()` accessor returns all sub-principals.
- [x] `go test ./...` — all packages pass.
- [x] `go vet ./...` — clean.

## Notes on scope

- No changes to `Principal.Type()` semantics, handler logic, the `ServiceKeyCreationAuthorizer` interface, or any authorizer implementation.
- No renames. The new `Principals()` accessor on `PrincipalMux` is the only API addition outside of the predicate functions themselves.

Made with [Cursor](https://cursor.com)