### PR TITLE
auth: make IsService/IsUser/IsMachine recursively unwrap nested PrincipalMux

### DIFF
--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -318,26 +318,48 @@ type httpClient interface {
 	Do(req *http.Request) (resp *http.Response, err error)
 }
 
-// IsUser returns true if the principal is a user, or if the principal is a
-// (possibly nested) PrincipalMux that contains at least one user sub-principal
-// at any depth.
-func IsUser(p knox.Principal) bool {
-	if _, ok := p.(user); ok {
+// maxPrincipalMuxDepth caps recursion when IsUser, IsService, and IsMachine
+// unwrap nested PrincipalMux values. In production the principal graph is
+// constructed by trusted server code and is at most ~3 levels deep (an outer
+// Authentication-decorator mux around a composite-provider mux around a leaf),
+// so this cap is wildly generous and never trips on well-formed input. It
+// exists purely as a defensive guard against pathological mux constructions:
+// without it, a buggy provider that returned a mux containing itself in its
+// allPrincipals map would hang the request handler in unbounded recursion.
+const maxPrincipalMuxDepth = 32
+
+// principalMatches reports whether p, recursively unwrapping any nested
+// knox.PrincipalMux values, contains a leaf principal for which match returns
+// true. Recursion is bounded by maxPrincipalMuxDepth.
+func principalMatches(p knox.Principal, match func(knox.Principal) bool, depth int) bool {
+	if match(p) {
 		return true
 	}
-	if mux, ok := p.(knox.PrincipalMux); ok {
-		for _, sub := range mux.Principals() {
-			if IsUser(sub) {
-				return true
-			}
+	if depth >= maxPrincipalMuxDepth {
+		return false
+	}
+	mux, ok := p.(knox.PrincipalMux)
+	if !ok {
+		return false
+	}
+	for _, sub := range mux.Principals() {
+		if principalMatches(sub, match, depth+1) {
+			return true
 		}
 	}
 	return false
 }
 
+// IsUser returns true if the principal is a user, or if the principal is a
+// (possibly nested) PrincipalMux that contains at least one user sub-principal
+// at any depth up to maxPrincipalMuxDepth.
+func IsUser(p knox.Principal) bool {
+	return principalMatches(p, isUserLeaf, 0)
+}
+
 // IsService returns true if the principal is a service, or if the principal is
 // a (possibly nested) PrincipalMux that contains at least one service
-// sub-principal at any depth.
+// sub-principal at any depth up to maxPrincipalMuxDepth.
 //
 // This sees through PrincipalMux deliberately: in multi-provider auth chains a
 // real service principal is often wrapped in a mux whose default is a different
@@ -348,35 +370,23 @@ func IsUser(p knox.Principal) bool {
 // may itself return a PrincipalMux, so the principal that reaches a handler can
 // be a mux of muxes. The recursion below resolves that case correctly.
 func IsService(p knox.Principal) bool {
-	if _, ok := p.(service); ok {
-		return true
-	}
-	if mux, ok := p.(knox.PrincipalMux); ok {
-		for _, sub := range mux.Principals() {
-			if IsService(sub) {
-				return true
-			}
-		}
-	}
-	return false
+	return principalMatches(p, isServiceLeaf, 0)
 }
 
 // IsMachine returns true if the principal is a machine, or if the principal is
 // a (possibly nested) PrincipalMux that contains at least one machine
-// sub-principal at any depth.
+// sub-principal at any depth up to maxPrincipalMuxDepth.
 func IsMachine(p knox.Principal) bool {
-	if _, ok := p.(machine); ok {
-		return true
-	}
-	if mux, ok := p.(knox.PrincipalMux); ok {
-		for _, sub := range mux.Principals() {
-			if IsMachine(sub) {
-				return true
-			}
-		}
-	}
-	return false
+	return principalMatches(p, isMachineLeaf, 0)
 }
+
+// isUserLeaf, isServiceLeaf, and isMachineLeaf are the leaf-only type tests
+// used by the corresponding Is* predicates. They are defined as package-level
+// functions (rather than inline closures) so each Is* call passes a stable
+// function value and avoids any per-call closure construction.
+func isUserLeaf(p knox.Principal) bool    { _, ok := p.(user); return ok }
+func isServiceLeaf(p knox.Principal) bool { _, ok := p.(service); return ok }
+func isMachineLeaf(p knox.Principal) bool { _, ok := p.(machine); return ok }
 
 type stringSet map[string]struct{}
 

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -319,14 +319,15 @@ type httpClient interface {
 }
 
 // IsUser returns true if the principal is a user, or if the principal is a
-// PrincipalMux that contains at least one user sub-principal.
+// (possibly nested) PrincipalMux that contains at least one user sub-principal
+// at any depth.
 func IsUser(p knox.Principal) bool {
 	if _, ok := p.(user); ok {
 		return true
 	}
 	if mux, ok := p.(knox.PrincipalMux); ok {
 		for _, sub := range mux.Principals() {
-			if _, ok := sub.(user); ok {
+			if IsUser(sub) {
 				return true
 			}
 		}
@@ -335,19 +336,24 @@ func IsUser(p knox.Principal) bool {
 }
 
 // IsService returns true if the principal is a service, or if the principal is
-// a PrincipalMux that contains at least one service sub-principal.
+// a (possibly nested) PrincipalMux that contains at least one service
+// sub-principal at any depth.
 //
 // This sees through PrincipalMux deliberately: in multi-provider auth chains a
 // real service principal is often wrapped in a mux whose default is a different
 // principal type, so a strict default-only check would incorrectly reject real
-// service requests in any code path that gates on IsService.
+// service requests in any code path that gates on IsService. The Authentication
+// HTTP decorator wraps whatever a provider returns in a PrincipalMux, and a
+// composite provider (e.g. one that itself runs a per-account provider chain)
+// may itself return a PrincipalMux, so the principal that reaches a handler can
+// be a mux of muxes. The recursion below resolves that case correctly.
 func IsService(p knox.Principal) bool {
 	if _, ok := p.(service); ok {
 		return true
 	}
 	if mux, ok := p.(knox.PrincipalMux); ok {
 		for _, sub := range mux.Principals() {
-			if _, ok := sub.(service); ok {
+			if IsService(sub) {
 				return true
 			}
 		}
@@ -356,14 +362,15 @@ func IsService(p knox.Principal) bool {
 }
 
 // IsMachine returns true if the principal is a machine, or if the principal is
-// a PrincipalMux that contains at least one machine sub-principal.
+// a (possibly nested) PrincipalMux that contains at least one machine
+// sub-principal at any depth.
 func IsMachine(p knox.Principal) bool {
 	if _, ok := p.(machine); ok {
 		return true
 	}
 	if mux, ok := p.(knox.PrincipalMux); ok {
 		for _, sub := range mux.Principals() {
-			if _, ok := sub.(machine); ok {
+			if IsMachine(sub) {
 				return true
 			}
 		}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -322,11 +322,12 @@ type httpClient interface {
 // unwrap nested PrincipalMux values. In production the principal graph is
 // constructed by trusted server code and is at most ~3 levels deep (an outer
 // Authentication-decorator mux around a composite-provider mux around a leaf),
-// so this cap is wildly generous and never trips on well-formed input. It
-// exists purely as a defensive guard against pathological mux constructions:
-// without it, a buggy provider that returned a mux containing itself in its
-// allPrincipals map would hang the request handler in unbounded recursion.
-const maxPrincipalMuxDepth = 32
+// so this cap leaves a small amount of headroom for additional wrapping and
+// is not expected to trip on well-formed input. It exists purely as a
+// defensive guard against pathological mux constructions: without it, a buggy
+// provider that returned a mux containing itself in its allPrincipals map
+// would hang the request handler in unbounded recursion.
+const maxPrincipalMuxDepth = 5
 
 // principalMatches reports whether p, recursively unwrapping any nested
 // knox.PrincipalMux values, contains a leaf principal for which match returns

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -342,6 +342,34 @@ func TestIsService_DeeperNesting(t *testing.T) {
 	}
 }
 
+func TestIsService_DepthGate(t *testing.T) {
+	// Defensive: a pathologically deep mux chain should not hang the predicate
+	// (which would happen with unbounded recursion + a stack-overflow-sized
+	// chain) and should return false past the cap. At exactly the cap depth
+	// the leaf must still be found.
+	svc := NewService("pin220.com", "k8s/example/username/test")
+
+	// Build a chain whose total depth (number of PrincipalMux wrappers between
+	// the public API call and the leaf) is exactly maxPrincipalMuxDepth. The
+	// public IsService starts at depth 0 and increments depth before each
+	// recursive call into a sub-principal, so a chain of N wrappers requires
+	// the helper to accept at least depth == N to find the leaf.
+	atCap := knox.Principal(svc)
+	for i := 0; i < maxPrincipalMuxDepth; i++ {
+		atCap = knox.NewPrincipalMux(atCap, map[string]knox.Principal{"l": atCap})
+	}
+	if !IsService(atCap) {
+		t.Errorf("IsService(chain of %d wrappers) = false, want true (leaf at the cap depth must still resolve)", maxPrincipalMuxDepth)
+	}
+
+	// One level deeper than the cap — the leaf is unreachable and the
+	// predicate must return false rather than recursing forever.
+	beyondCap := knox.NewPrincipalMux(atCap, map[string]knox.Principal{"l": atCap})
+	if IsService(beyondCap) {
+		t.Errorf("IsService(chain of %d wrappers) = true, want false (depth gate should refuse to recurse past the cap)", maxPrincipalMuxDepth+1)
+	}
+}
+
 func TestIsService_NestedMux_MixedLeaves(t *testing.T) {
 	// Inner mux contains a User; outer contains the inner mux plus a separate
 	// Service in a sibling sub-tree. Both predicates should return true

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -272,6 +272,99 @@ func TestIsServicePrincipalMuxMixedSubPrincipals(t *testing.T) {
 	}
 }
 
+func TestIsService_NestedPrincipalMux(t *testing.T) {
+	// In production, a composite provider can return a PrincipalMux, which the
+	// outer Authentication decorator then wraps in another PrincipalMux. The
+	// predicates must see through any depth of nesting.
+	svc := NewService("pin220.com", "k8s/example/username/test")
+	inner := knox.NewPrincipalMux(svc, map[string]knox.Principal{"spiffe": svc})
+	outer := knox.NewPrincipalMux(inner, map[string]knox.Principal{"composite": inner})
+
+	if !IsService(outer) {
+		t.Errorf("IsService(nested mux wrapping service) = false, want true")
+	}
+	if IsUser(outer) {
+		t.Errorf("IsUser(nested mux wrapping only service) = true, want false")
+	}
+	if IsMachine(outer) {
+		t.Errorf("IsMachine(nested mux wrapping only service) = true, want false")
+	}
+}
+
+func TestIsUser_NestedPrincipalMux(t *testing.T) {
+	u := NewUser("testuser", []string{"testgroup"})
+	inner := knox.NewPrincipalMux(u, map[string]knox.Principal{"github": u})
+	outer := knox.NewPrincipalMux(inner, map[string]knox.Principal{"composite": inner})
+
+	if !IsUser(outer) {
+		t.Errorf("IsUser(nested mux wrapping user) = false, want true")
+	}
+	if IsService(outer) {
+		t.Errorf("IsService(nested mux wrapping only user) = true, want false")
+	}
+	if IsMachine(outer) {
+		t.Errorf("IsMachine(nested mux wrapping only user) = true, want false")
+	}
+}
+
+func TestIsMachine_NestedPrincipalMux(t *testing.T) {
+	m := NewMachine("test001")
+	inner := knox.NewPrincipalMux(m, map[string]knox.Principal{"mtls": m})
+	outer := knox.NewPrincipalMux(inner, map[string]knox.Principal{"composite": inner})
+
+	if !IsMachine(outer) {
+		t.Errorf("IsMachine(nested mux wrapping machine) = false, want true")
+	}
+	if IsService(outer) {
+		t.Errorf("IsService(nested mux wrapping only machine) = true, want false")
+	}
+	if IsUser(outer) {
+		t.Errorf("IsUser(nested mux wrapping only machine) = true, want false")
+	}
+}
+
+func TestIsService_DeeperNesting(t *testing.T) {
+	// Three levels of PrincipalMux to prove the recursion isn't accidentally
+	// limited to two.
+	svc := NewService("pin220.com", "k8s/example/username/test")
+	l1 := knox.NewPrincipalMux(svc, map[string]knox.Principal{"a": svc})
+	l2 := knox.NewPrincipalMux(l1, map[string]knox.Principal{"b": l1})
+	l3 := knox.NewPrincipalMux(l2, map[string]knox.Principal{"c": l2})
+
+	if !IsService(l3) {
+		t.Errorf("IsService(3-level nested mux) = false, want true")
+	}
+	if IsUser(l3) {
+		t.Errorf("IsUser(3-level nested mux of service) = true, want false")
+	}
+	if IsMachine(l3) {
+		t.Errorf("IsMachine(3-level nested mux of service) = true, want false")
+	}
+}
+
+func TestIsService_NestedMux_MixedLeaves(t *testing.T) {
+	// Inner mux contains a User; outer contains the inner mux plus a separate
+	// Service in a sibling sub-tree. Both predicates should return true
+	// regardless of which sub-tree holds the leaf.
+	u := NewUser("testuser", nil)
+	svc := NewService("pin220.com", "k8s/example/username/test")
+	inner := knox.NewPrincipalMux(u, map[string]knox.Principal{"user": u})
+	outer := knox.NewPrincipalMux(inner, map[string]knox.Principal{
+		"userside":    inner,
+		"serviceside": svc,
+	})
+
+	if !IsUser(outer) {
+		t.Errorf("IsUser(outer with nested user) = false, want true")
+	}
+	if !IsService(outer) {
+		t.Errorf("IsService(outer with sibling service) = false, want true")
+	}
+	if IsMachine(outer) {
+		t.Errorf("IsMachine(outer with no machine) = true, want false")
+	}
+}
+
 func TestPrincipalMuxPrincipals(t *testing.T) {
 	u := NewUser("testuser", nil)
 	s := NewService("example.com", "serviceA")


### PR DESCRIPTION
## Summary

PR #124 made `auth.IsService`, `auth.IsUser`, and `auth.IsMachine` walk one level of `knox.PrincipalMux`, which fixed the common single-level case. In production, however, the principal reaching a handler can be a *nested* `PrincipalMux`: the outer `Authentication` decorator (`server/decorators.go`) always wraps whatever a provider returns into a new `PrincipalMux`, and a composite provider (e.g. an account-aware provider that itself runs a per-account provider chain) may itself return a `PrincipalMux`. The result is `outerMux(innerMux(leaf))`, and the one-level walk in #124 stops at `innerMux` — which isn't a leaf — and returns `false`.

Concretely, both of these `knox.NewPrincipalMux(...)` calls happen on every request when a deployment uses a composite provider:

1. **Outer mux** — `server/decorators.go` wraps the result of the provider chain:
   ```go
   SetPrincipal(r, knox.NewPrincipalMux(defaultPrincipal, allPrincipals))
   ```
2. **Inner mux** — a composite provider's `Authenticate` returns a `PrincipalMux` of its own (e.g. an account-aware provider that builds a per-account provider chain).

So `IsService(outerMux)` runs the post-#124 logic and:
- `_, ok := p.(service)` → false
- walks `outerMux.Principals()` → `[innerMux]`
- `_, ok := innerMux.(service)` → false (inner is also a mux)
- returns `false` ❌

This breaks any handler code path that gates on the OSS `Is*` predicates after auth — including the `postKeysHandler` user-vs-service branch and any `ServiceKeyCreationAuthorizer` implementation that does `if !auth.IsService(principal) { reject }`.

## Fix

Replace the direct leaf type assertion inside the mux-walk branch with a recursive call, so any depth of nesting resolves correctly. The recursion is consolidated into a single `principalMatches(p, match, depth)` helper that all three `Is*` predicates delegate to, passing a leaf-test function (`isServiceLeaf`, `isUserLeaf`, `isMachineLeaf` — package-level functions, no per-call closure allocation). The fast-path leaf assertion is preserved for callers that already pass a raw `*service`/`*user`/`*machine`.

```go
const maxPrincipalMuxDepth = 5

func principalMatches(p knox.Principal, match func(knox.Principal) bool, depth int) bool {
    if match(p) {
        return true
    }
    if depth >= maxPrincipalMuxDepth {
        return false
    }
    mux, ok := p.(knox.PrincipalMux)
    if !ok {
        return false
    }
    for _, sub := range mux.Principals() {
        if principalMatches(sub, match, depth+1) {
            return true
        }
    }
    return false
}

func IsService(p knox.Principal) bool { return principalMatches(p, isServiceLeaf, 0) }
```

### Depth gate (`maxPrincipalMuxDepth = 5`)

Production depth is ~3 (an outer Authentication-decorator mux around a composite-provider mux around a leaf), so 5 leaves a small amount of headroom for additional wrapping while keeping the cap close to the realistic worst case. The cap exists purely as a defensive guard against pathological mux constructions: a buggy provider that returns a mux containing itself in its `allPrincipals` map would otherwise hang the request handler in unbounded recursion. (`PrincipalMux` is a value type and `NewPrincipalMux` always creates a fresh value, so a true Go-level cycle can't actually exist; the cap protects against pathological-but-finite chains and against future refactors that might introduce reference cycles.)

`PrincipalMux.GetID()` already recurses correctly via interface dispatch (each level's `defaultPrincipal.GetID()` resolves through nested muxes naturally), so it is not touched. No handler logic, no `Principal.Type()` semantics, and no decorator behavior is changed — the fix is local to the predicates.

## Tests

Adds six new tests in `server/auth/auth_test.go`:

- `TestIsService_NestedPrincipalMux` — two-level mux wrapping a service.
- `TestIsUser_NestedPrincipalMux` — two-level mux wrapping a user.
- `TestIsMachine_NestedPrincipalMux` — two-level mux wrapping a machine.
- `TestIsService_DeeperNesting` — three-level mux, proves the recursion isn't accidentally limited to two.
- `TestIsService_DepthGate` — builds a chain of exactly `maxPrincipalMuxDepth` wrappers and asserts the leaf is still found, then adds one more wrapper and asserts the predicate refuses to recurse past the cap.
- `TestIsService_NestedMux_MixedLeaves` — outer mux holds an inner mux of users plus a sibling service principal; both `IsUser` and `IsService` must return true.

All previously existing tests (single-level mux and raw leaves) continue to pass unchanged.

## Test plan

- [x] `go test ./server/auth/...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (full repo)
- [x] No files outside `server/auth/` modified