### PR TITLE
client: allow ACL to be provided at key creation via -acl flag

### DIFF
--- a/client/create.go
+++ b/client/create.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 var cmdCreate = &Command{
-	UsageLine: "create [--key-template template_name] <key_identifier>",
+	UsageLine: "create [--key-template template_name] [-acl acl_file] <key_identifier>",
 	Short:     "creates a new key",
 	Long: `
 Create will create a new key in knox with input as the primary key version. Key data should be sent to stdin unless a key-template is specified.
@@ -23,6 +23,8 @@ Please run "knox create <key_identifier>".
 
 Second way: the key-template option can be used to specify a template to generate the initial primary key version, instead of stdin. For available key templates, run "knox key-templates".
 Please run "knox create --key-template <template_name> <key_identifier>".
+
+-acl: Takes in a filename with a JSON formatted list of access rules to set on the key at creation time, in the same format as "knox access -acl".
 
 The original key version id will be print to stdout.
 
@@ -34,14 +36,25 @@ See also: knox add, knox get
 	`,
 }
 var createTinkKeyset = cmdCreate.Flag.String("key-template", "", "name of a knox-supported Tink key template")
+var createACL = cmdCreate.Flag.String("acl", "", "file containing a JSON formatted list of access rules")
 
 func runCreate(cmd *Command, args []string) *ErrorStatus {
 	if len(args) != 1 {
 		return &ErrorStatus{fmt.Errorf("create takes exactly one argument; see 'knox help create'"), false}
 	}
 	keyID := args[0]
-	var data []byte
 	var err error
+	// Parse the ACL file (if any) before reading key data so that an
+	// unreadable or malformed file fails fast, without first consuming the
+	// user's secret from stdin.
+	acl := knox.ACL{}
+	if *createACL != "" {
+		acl, err = parseACLFile(*createACL)
+		if err != nil {
+			return &ErrorStatus{err, false}
+		}
+	}
+	var data []byte
 	if *createTinkKeyset != "" {
 		templateName := *createTinkKeyset
 		err = obeyNamingRule(templateName, keyID)
@@ -55,8 +68,6 @@ func runCreate(cmd *Command, args []string) *ErrorStatus {
 	if err != nil {
 		return &ErrorStatus{err, false}
 	}
-	// TODO(devinlundberg): allow ACL to be entered as input
-	acl := knox.ACL{}
 	versionID, err := cli.CreateKey(keyID, data, acl)
 	if err != nil {
 		return &ErrorStatus{fmt.Errorf("error adding version: %w", err), true}

--- a/client/create_test.go
+++ b/client/create_test.go
@@ -1,0 +1,193 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/pinterest/knox"
+)
+
+func TestParseACLFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name, contents string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+		return path
+	}
+
+	testCases := []struct {
+		name   string
+		path   string
+		acl    knox.ACL
+		errMsg string
+	}{
+		{
+			name: "valid acl file",
+			path: writeFile("valid.json", `[{"type":"User","id":"testuser","access":"Admin"},{"type":"MachinePrefix","id":"auth","access":"Read"}]`),
+			acl: knox.ACL{
+				{Type: knox.User, ID: "testuser", AccessType: knox.Admin},
+				{Type: knox.MachinePrefix, ID: "auth", AccessType: knox.Read},
+			},
+		},
+		{
+			name:   "missing file",
+			path:   filepath.Join(dir, "does-not-exist.json"),
+			errMsg: "could not read acl file",
+		},
+		{
+			name:   "malformed json",
+			path:   writeFile("malformed.json", `[{"type":"User",`),
+			errMsg: "could not decode access list properly",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			acl, err := parseACLFile(tc.path)
+			if tc.errMsg != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.errMsg)
+				}
+				if !strings.Contains(err.Error(), tc.errMsg) {
+					t.Errorf("expected %q in error, got: %v", tc.errMsg, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected nil error, got: %v", err)
+			}
+			if !reflect.DeepEqual(acl, tc.acl) {
+				t.Errorf("expected acl %v, got %v", tc.acl, acl)
+			}
+		})
+	}
+}
+
+// mockCreateServer creates a test server that records the acl form value sent
+// on key creation requests.
+func mockCreateServer(t *testing.T, gotACL *string) *httptest.Server {
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotACL = r.PostFormValue("acl")
+		resp := &knox.Response{
+			Status:    "ok",
+			Code:      knox.OKCode,
+			Host:      "test",
+			Timestamp: 1234567890,
+			Message:   "",
+			Data:      uint64(1),
+		}
+		data, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("failed to marshal response: %v", err)
+		}
+		w.WriteHeader(200)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	}))
+}
+
+func TestRunCreateACL(t *testing.T) {
+	dir := t.TempDir()
+	aclFile := filepath.Join(dir, "acl.json")
+	if err := os.WriteFile(aclFile, []byte(`[{"type":"User","id":"testuser","access":"Admin"}]`), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	testCases := []struct {
+		name    string
+		aclFlag string
+		wantACL string
+		errMsg  string
+	}{
+		{
+			name:    "no acl flag sends empty acl",
+			aclFlag: "",
+			wantACL: "[]",
+		},
+		{
+			name:    "acl flag sends parsed acl",
+			aclFlag: aclFile,
+			wantACL: `[{"type":"User","id":"testuser","access":"Admin"}]`,
+		},
+		{
+			name:    "missing acl file",
+			aclFlag: filepath.Join(dir, "does-not-exist.json"),
+			errMsg:  "could not read acl file",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotACL string
+			srv := mockCreateServer(t, &gotACL)
+			defer srv.Close()
+
+			// Save original cli and flag values, restore after test
+			origCli := cli
+			origCreateACL := *createACL
+			defer func() {
+				cli = origCli
+				*createACL = origCreateACL
+			}()
+
+			cli = knox.NewUncachedClient(
+				srv.Listener.Addr().String(),
+				srv.Client(),
+				[]knox.AuthHandler{func() (string, string, knox.HTTP) { return "test", "0utest", nil }},
+				"test-version",
+			)
+
+			*createACL = tc.aclFlag
+
+			// Send key data to stdin
+			oldStdin := os.Stdin
+			stdinR, stdinW, _ := os.Pipe()
+			os.Stdin = stdinR
+			stdinW.Write([]byte("keydata"))
+			stdinW.Close()
+			defer func() { os.Stdin = oldStdin }()
+
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			result := runCreate(nil, []string{"testkey"})
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+
+			if tc.errMsg != "" {
+				if result == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.errMsg)
+				}
+				if !strings.Contains(result.Error(), tc.errMsg) {
+					t.Errorf("expected %q in error, got: %v", tc.errMsg, result.error)
+				}
+				if result.serverError {
+					t.Errorf("expected non-server error, got server error: %v", result.error)
+				}
+				return
+			}
+			if result != nil {
+				t.Fatalf("expected nil error, got: %v", result.error)
+			}
+			if gotACL != tc.wantACL {
+				t.Errorf("expected acl %s, got %s", tc.wantACL, gotACL)
+			}
+		})
+	}
+}

--- a/client/updateaccess.go
+++ b/client/updateaccess.go
@@ -60,14 +60,9 @@ func runUpdateAccess(cmd *Command, args []string) *ErrorStatus {
 			return &ErrorStatus{fmt.Errorf("access takes one argument when used with --acl; see 'knox help access'"), false}
 		}
 		keyID := args[0]
-		b, err := os.ReadFile(*updateAccessACL)
+		acl, err := parseACLFile(*updateAccessACL)
 		if err != nil {
-			return &ErrorStatus{fmt.Errorf("could not read acl file: %w", err), false}
-		}
-		acl := []knox.Access{}
-		err = json.Unmarshal(b, &acl)
-		if err != nil {
-			return &ErrorStatus{fmt.Errorf("could not decode access list properly: %w", err), false}
+			return &ErrorStatus{err, false}
 		}
 		err = cli.PutAccess(keyID, acl...)
 		if err != nil {
@@ -117,4 +112,19 @@ func runUpdateAccess(cmd *Command, args []string) *ErrorStatus {
 	}
 	fmt.Println("Successfully updated Access")
 	return nil
+}
+
+// parseACLFile reads a JSON formatted list of access rules from the file at
+// the given path.
+func parseACLFile(path string) (knox.ACL, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not read acl file: %w", err)
+	}
+	acl := knox.ACL{}
+	err = json.Unmarshal(b, &acl)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode access list properly: %w", err)
+	}
+	return acl, nil
 }


### PR DESCRIPTION
Currently `knox create` always creates keys with an empty ACL, so applying
access controls is a two-step workflow: `knox create`, then
`knox access -acl <file> <key>`. Between those two steps the key exists
without its intended access controls. This PR resolves the
`TODO(devinlundberg): allow ACL to be entered as input` in
`client/create.go` by letting the ACL be supplied at creation time:

    knox create -acl acl.json my_service:my_key

`-acl` takes a JSON file containing a list of access rules, in the exact
same format already accepted by `knox access -acl`. When the flag is
omitted, behavior is unchanged (empty ACL).

### Changes

- Extracted the ACL file read/parse logic from `runUpdateAccess` into a
  shared `parseACLFile` helper, now used by both `knox access -acl` and
  `knox create -acl`. No behavior change for `knox access`.
- Added the `-acl` flag to `knox create`. The ACL file is parsed **before**
  key data is read from stdin, so an unreadable or malformed file fails
  fast without first consuming the user's secret. Unreadable files and
  invalid JSON return user-facing (non-server) errors, consistent with the
  existing input validation in the command.
- Updated `knox create` usage and help text to document the flag.

### Tests

- `TestParseACLFile`: table-driven coverage of a valid ACL file, a missing
  file, and malformed JSON.
- `TestRunCreateACL`: table-driven coverage of `runCreate` against a mock
  server, verifying that no flag still sends an empty ACL (`[]`), that a
  provided ACL file is parsed and sent on the wire, and that a missing file
  yields a non-server error.

All of `go build ./...`, `go vet ./...`, `gofmt -d -s .`, and
`go test ./...` pass.