### PR TITLE
server: enforce per-key ACL on the bulk key-listing route

### DIFF
--- a/server/getkeys_authorization_test.go
+++ b/server/getkeys_authorization_test.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/pinterest/knox"
+	"github.com/pinterest/knox/server/auth"
+)
+
+// Regression test for: GET /v0/keys/ (getKeysHandler, no query string) used to
+// return every key ID in the instance via KeyManager.GetAllKeyIDs(), with no
+// ACL check at all. Every other single-key route (getKeyHandler,
+// deleteKeyHandler, putAccessHandler, ...) calls authorizeRequest(key,
+// principal, ...) before returning anything; this bulk-listing route did not.
+//
+// Key IDs are not meant to be public: they routinely encode team, project, or
+// vendor names (e.g. "stripe_prod_api_key"), which is exactly the kind of
+// information a secrets manager's own ACLs are meant to keep scoped to
+// authorized principals -- it is valuable reconnaissance for an attacker who
+// holds any valid Knox credential at all, however low-privileged.
+func TestGetAllKeyIDsOnlyReturnsKeysThePrincipalCanRead(t *testing.T) {
+	m, _ := makeDB()
+
+	owner := auth.NewUser("team-payments-owner", nil)
+	if _, err := postKeysHandler(m, owner, map[string]string{
+		"id":   "stripe_prod_api_key",
+		"data": "c2VjcmV0",
+	}); err != nil {
+		t.Fatalf("failed to create key: %v", err)
+	}
+	if _, err := postKeysHandler(m, owner, map[string]string{
+		"id":   "internal_admin_jwt_secret",
+		"data": "c2VjcmV0",
+	}); err != nil {
+		t.Fatalf("failed to create key: %v", err)
+	}
+
+	// A machine principal with zero ACL grants anywhere -- it was never added
+	// to either key's ACL, and has no relationship to the owner. This models
+	// the lowest-trust caller Knox can authenticate: any host that can present
+	// a cert signed by Knox's CA.
+	attacker := auth.NewMachine("unrelated-low-trust-host")
+
+	// Confirm the attacker genuinely has no access to either key, the same way
+	// getKeyHandler would enforce it.
+	keyA, err := m.GetKey("stripe_prod_api_key", knox.Active)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attacker.CanAccess(keyA.ACL, knox.Read) {
+		t.Fatal("test setup invalid: attacker should not have Read access")
+	}
+
+	result, apiErr := getKeysHandler(m, attacker, nil)
+	if apiErr != nil {
+		t.Fatalf("getKeysHandler returned an error: %+v", apiErr)
+	}
+	ids, ok := result.([]string)
+	if !ok {
+		t.Fatalf("unexpected response type %T", result)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("VULNERABLE: principal with zero ACL grants enumerated key IDs it cannot read: %v", ids)
+	}
+
+	// The owner, who does have access, must still see both keys.
+	result, apiErr = getKeysHandler(m, owner, nil)
+	if apiErr != nil {
+		t.Fatalf("getKeysHandler returned an error: %+v", apiErr)
+	}
+	ownerIDs, ok := result.([]string)
+	if !ok {
+		t.Fatalf("unexpected response type %T", result)
+	}
+	found := map[string]bool{}
+	for _, id := range ownerIDs {
+		found[id] = true
+	}
+	if !found["stripe_prod_api_key"] || !found["internal_admin_jwt_secret"] {
+		t.Fatalf("owner should see both of their own keys, got: %v", ownerIDs)
+	}
+
+	// A principal explicitly granted Read on only one of the two keys should
+	// see exactly that one, not both.
+	reader := auth.NewUser("payments-oncall-reader", nil)
+	if err := m.UpdateAccess("stripe_prod_api_key", knox.Access{
+		Type: knox.User, ID: reader.GetID(), AccessType: knox.Read,
+	}); err != nil {
+		t.Fatalf("failed to grant access: %v", err)
+	}
+
+	result, apiErr = getKeysHandler(m, reader, nil)
+	if apiErr != nil {
+		t.Fatalf("getKeysHandler returned an error: %+v", apiErr)
+	}
+	readerIDs, ok := result.([]string)
+	if !ok {
+		t.Fatalf("unexpected response type %T", result)
+	}
+	if len(readerIDs) != 1 || readerIDs[0] != "stripe_prod_api_key" {
+		t.Fatalf("reader should see exactly the one key it was granted, got: %v", readerIDs)
+	}
+}

--- a/server/key_manager.go
+++ b/server/key_manager.go
@@ -9,8 +9,8 @@ import (
 
 // KeyManager is the interface for logic related to managing keys.
 type KeyManager interface {
-	GetAllKeyIDs() ([]string, error)
-	GetUpdatedKeyIDs(map[string]string) ([]string, error)
+	GetAllKeyIDs(principal knox.Principal) ([]string, error)
+	GetUpdatedKeyIDs(principal knox.Principal, versions map[string]string) ([]string, error)
 	GetKey(id string, status knox.VersionStatus) (*knox.Key, error)
 	AddNewKey(*knox.Key) error
 	DeleteKey(id string) error
@@ -29,26 +29,36 @@ type keyManager struct {
 	db      keydb.DB
 }
 
-func (m *keyManager) GetAllKeyIDs() ([]string, error) {
+// GetAllKeyIDs returns the IDs of every key that principal has at least Read
+// access to. Key IDs are not public: they routinely encode team, project, or
+// vendor names (e.g. "stripe_prod_api_key"), which is exactly the kind of
+// information a secrets manager's own ACLs are meant to keep scoped to
+// authorized principals.
+func (m *keyManager) GetAllKeyIDs(principal knox.Principal) ([]string, error) {
 	keys, err := m.db.GetAll()
 	if err != nil {
 		return nil, err
 	}
 	output := []string{}
 	for _, k := range keys {
-		output = append(output, k.ID)
+		if principal.CanAccess(k.ACL, knox.Read) {
+			output = append(output, k.ID)
+		}
 	}
 	return output, nil
 }
 
-func (m *keyManager) GetUpdatedKeyIDs(versions map[string]string) ([]string, error) {
+// GetUpdatedKeyIDs returns the IDs, among the ones principal has at least Read
+// access to, whose version hash no longer matches the value the caller
+// already has cached.
+func (m *keyManager) GetUpdatedKeyIDs(principal knox.Principal, versions map[string]string) ([]string, error) {
 	keys, err := m.db.GetAll()
 	if err != nil {
 		return nil, err
 	}
 	output := []string{}
 	for _, k := range keys {
-		if v, ok := versions[k.ID]; ok && k.VersionHash != v {
+		if v, ok := versions[k.ID]; ok && k.VersionHash != v && principal.CanAccess(k.ACL, knox.Read) {
 			output = append(output, k.ID)
 		}
 	}

--- a/server/key_manager_test.go
+++ b/server/key_manager_test.go
@@ -33,7 +33,7 @@ func (p mockPrincipal) GetID() string {
 
 func TestGetAllKeyIDs(t *testing.T) {
 	m, u, acl := GetMocks()
-	keys, err := m.GetAllKeyIDs()
+	keys, err := m.GetAllKeyIDs(u)
 	if err != nil {
 		t.Fatalf("%s is not nil", err)
 	}
@@ -47,7 +47,7 @@ func TestGetAllKeyIDs(t *testing.T) {
 		t.Fatalf("%s is not nil", err)
 	}
 
-	keys, err = m.GetAllKeyIDs()
+	keys, err = m.GetAllKeyIDs(u)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -65,7 +65,7 @@ func TestGetAllKeyIDs(t *testing.T) {
 		t.Fatalf("%s is not nil", err)
 	}
 
-	keys, err = m.GetAllKeyIDs()
+	keys, err = m.GetAllKeyIDs(u)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -89,7 +89,7 @@ func TestGetAllKeyIDs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s is not nil", err)
 	}
-	keys, err = m.GetAllKeyIDs()
+	keys, err = m.GetAllKeyIDs(u)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -104,7 +104,7 @@ func TestGetAllKeyIDs(t *testing.T) {
 
 func TestGetUpdatedKeyIDs(t *testing.T) {
 	m, u, acl := GetMocks()
-	keys, err := m.GetUpdatedKeyIDs(map[string]string{})
+	keys, err := m.GetUpdatedKeyIDs(u, map[string]string{})
 	if err != nil {
 		t.Fatalf("%s is not nil", err)
 	}
@@ -118,7 +118,7 @@ func TestGetUpdatedKeyIDs(t *testing.T) {
 		t.Fatalf("%s is not nil", err)
 	}
 
-	keys, err = m.GetUpdatedKeyIDs(map[string]string{key1.ID: "NOT_THE_HASH"})
+	keys, err = m.GetUpdatedKeyIDs(u, map[string]string{key1.ID: "NOT_THE_HASH"})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -130,7 +130,7 @@ func TestGetUpdatedKeyIDs(t *testing.T) {
 		t.Fatal("Unexpected # of keys in get all keys response")
 	}
 
-	keys, err = m.GetUpdatedKeyIDs(map[string]string{key1.ID: key1.VersionHash})
+	keys, err = m.GetUpdatedKeyIDs(u, map[string]string{key1.ID: key1.VersionHash})
 	if len(keys) != 0 {
 		t.Fatal("database should have no keys in it")
 	}
@@ -141,7 +141,7 @@ func TestGetUpdatedKeyIDs(t *testing.T) {
 		t.Fatalf("%s is not nil", err)
 	}
 
-	keys, err = m.GetUpdatedKeyIDs(map[string]string{key2.ID: "NOT_THE_HASH"})
+	keys, err = m.GetUpdatedKeyIDs(u, map[string]string{key2.ID: "NOT_THE_HASH"})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -153,7 +153,7 @@ func TestGetUpdatedKeyIDs(t *testing.T) {
 		t.Fatal("Unexpected # of keys in get all keys response")
 	}
 
-	keys, err = m.GetUpdatedKeyIDs(map[string]string{key2.ID: "NOT_THE_HASH", key1.ID: "NOT_THE_HASH"})
+	keys, err = m.GetUpdatedKeyIDs(u, map[string]string{key2.ID: "NOT_THE_HASH", key1.ID: "NOT_THE_HASH"})
 	if len(keys) != 2 {
 		t.Fatalf("Expect 2 keys not %d", len(keys))
 	}
@@ -169,7 +169,7 @@ func TestGetUpdatedKeyIDs(t *testing.T) {
 		t.Fatal("Unexpected key ID returned")
 	}
 
-	keys, err = m.GetUpdatedKeyIDs(map[string]string{key2.ID: key2.VersionHash, key1.ID: "NOT_THE_HASH"})
+	keys, err = m.GetUpdatedKeyIDs(u, map[string]string{key2.ID: key2.VersionHash, key1.ID: "NOT_THE_HASH"})
 	if len(keys) != 1 {
 		t.Fatalf("Expect 1 key not %d", len(keys))
 	}
@@ -177,7 +177,7 @@ func TestGetUpdatedKeyIDs(t *testing.T) {
 		t.Fatalf("%s does not match %s", keys[0], key1.ID)
 	}
 
-	keys, err = m.GetUpdatedKeyIDs(map[string]string{key2.ID: key2.VersionHash, key1.ID: key1.VersionHash})
+	keys, err = m.GetUpdatedKeyIDs(u, map[string]string{key2.ID: key2.VersionHash, key1.ID: key1.VersionHash})
 	if len(keys) != 0 {
 		t.Fatal("expected no keys")
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -119,14 +119,14 @@ func getKeysHandler(m KeyManager, principal knox.Principal, parameters map[strin
 
 	// Get necessary data based on parameters
 	if len(keyMap) == 0 {
-		keys, err := m.GetAllKeyIDs()
+		keys, err := m.GetAllKeyIDs(principal)
 		if err != nil {
 			return nil, errF(knox.InternalServerErrorCode, err.Error())
 		}
 		return keys, nil
 	}
 
-	keys, err := m.GetUpdatedKeyIDs(keyM)
+	keys, err := m.GetUpdatedKeyIDs(principal, keyM)
 	if err != nil {
 		return nil, errF(knox.InternalServerErrorCode, err.Error())
 	}


### PR DESCRIPTION
GET /v0/keys/ with no query string (getKeysHandler's list-all path) returns every key ID in the instance through KeyManager.GetAllKeyIDs(), with no ACL check anywhere in the call path. Every single-key route (getKeyHandler, deleteKeyHandler, putAccessHandler, ...) calls authorizeRequest before returning anything; this one doesn't, so any principal that can authenticate at all -- a machine with an mTLS cert, a service, any user -- gets the full list of key IDs regardless of whether it has a grant on any of them.

Key IDs aren't meant to be public: they're chosen by whoever creates the key and routinely encode what the secret is for, which is exactly the kind of thing an ACL is supposed to keep scoped.

GetAllKeyIDs and GetUpdatedKeyIDs now take the calling principal and filter to keys the principal has at least Read access to. ACL is stored unencrypted in DBKey already, so this doesn't need to decrypt key data to filter -- it's just checking principal.CanAccess(k.ACL, knox.Read) against the same ACL that authorizeRequest already checks for single-key routes. Added a test covering: an unrelated principal with no grants sees nothing, the owner still sees both of their keys, and a principal granted Read on only one of two keys sees exactly that one.